### PR TITLE
feat: improve mobile layout responsiveness

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -89,7 +89,8 @@ export function AppSidebar() {
     const isActive = location.pathname === path;
     return `flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 ${isActive ? 'bg-marine-100 text-marine-700 font-medium' : 'text-white/80 hover:text-white hover:bg-white/10'}`;
   };
-  return <Sidebar className="w-52 sm:w-56 lg:w-64 gradient-ocean wave-pattern">
+  return (
+    <Sidebar className={`${!isMobile ? 'hidden sm:block' : ''} w-52 sm:w-56 lg:w-64 gradient-ocean wave-pattern`}>
       <SidebarContent className="p-2 sm:p-3 lg:p-4">
         <SidebarGroup>
           <SidebarGroupLabel className="text-white/60 text-xs uppercase tracking-wide mb-2 sm:mb-3 lg:mb-4">
@@ -120,5 +121,6 @@ export function AppSidebar() {
           </p>
         </div>
       </SidebarContent>
-    </Sidebar>;
+    </Sidebar>
+  );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -45,7 +45,7 @@ export const Header = () => {
           <div className="w-5 h-5 sm:w-6 sm:h-6 lg:w-8 lg:h-8 bg-gradient-to-br from-marine-500 to-ocean-500 rounded-lg flex items-center justify-center flex-shrink-0">
             <span className="text-white font-bold text-xs lg:text-sm">CC</span>
           </div>
-          <h1 className="text-sm sm:text-lg lg:text-xl font-semibold text-gray-900 hidden xs:block truncate">Corail Caraibes</h1>
+          <h1 className="text-xs sm:text-lg lg:text-xl font-semibold text-gray-900 hidden xs:block truncate">Corail Caraibes</h1>
         </div>
       </div>
 
@@ -57,7 +57,7 @@ export const Header = () => {
             <Button variant="ghost" className="flex items-center gap-1 sm:gap-2 lg:gap-3 h-auto p-1 lg:p-2">
               <div className="text-right hidden md:block">
                 <div className="font-medium text-xs sm:text-sm truncate max-w-24 lg:max-w-none">{user?.name}</div>
-                <Badge className={`text-xs ${getRoleBadgeColor(user?.role || '')}`}>
+                <Badge className={`text-xs truncate ${getRoleBadgeColor(user?.role || '')}`}>
                   {getRoleLabel(user?.role || '')}
                 </Badge>
               </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -28,7 +28,7 @@ export const Layout = ({ children }: LayoutProps) => {
   // Pour les pages authentifiées, on affiche le layout complet
   return (
     <SidebarProvider defaultOpen={false}>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex flex-col sm:flex-row w-full bg-slate-50">
         <AppSidebar />
         <div className="flex-1 flex flex-col overflow-hidden min-w-0">
           <Header />


### PR DESCRIPTION
## Summary
- hide sidebar below small screens and expose navigation via menu trigger
- stack layout vertically on mobile with flex-col
- tighten header text and badge styles for small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688e65d9d9d0832db14930615477a1b8