### PR TITLE
feat: improve card grid responsiveness

### DIFF
--- a/src/components/maintenance/InterventionCards.tsx
+++ b/src/components/maintenance/InterventionCards.tsx
@@ -69,7 +69,7 @@ export function InterventionCards({
   }
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
       {interventions.map((intervention) => {
         const StatusIcon = statusIcons[intervention.status as keyof typeof statusIcons];
         

--- a/src/components/orders/OrderCards.tsx
+++ b/src/components/orders/OrderCards.tsx
@@ -89,10 +89,10 @@ export function OrderCards({ orders, isLoading, onEdit, onViewDetails, canManage
   };
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
       {orders.map((order) => (
-        <Card 
-          key={order.id} 
+        <Card
+          key={order.id}
           className="hover:shadow-md transition-shadow cursor-pointer"
           onClick={() => onViewDetails(order)}
         >

--- a/src/components/stock/StockCards.tsx
+++ b/src/components/stock/StockCards.tsx
@@ -171,7 +171,7 @@ export function StockCards({ items, isLoading, onEdit, onDuplicate, onUpdateQuan
   }
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-6">
       {memoizedItems.map((item) => (
         <StockCard
           key={item.id}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm p-3 sm:p-4 lg:p-6",
+      "w-full max-w-full rounded-lg border bg-card text-card-foreground shadow-sm p-3 sm:p-4 lg:p-6",
       className
     )}
     {...props}

--- a/src/pages/Boats.tsx
+++ b/src/pages/Boats.tsx
@@ -332,7 +332,7 @@ export default function Boats() {
       </div>
 
       {/* Boats Grid */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
         {filteredBoats.map(boat => <BoatCard key={boat.id} boat={boat} onEdit={handleEdit} onDelete={handleDelete} onHistory={handleHistory} onPreventiveMaintenance={handlePreventiveMaintenance} canManage={canManageBoats} />)}
       </div>
 


### PR DESCRIPTION
## Summary
- ensure Card component spans full width
- make card grids responsive with `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`
- add adaptive gaps for consistent spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install --legacy-peer-deps` *(fails: dependency conflict)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e65d88d48832db0be0fcf227168c9