### PR TITLE
fix: show single column stats on mobile

### DIFF
--- a/src/pages/Boats.tsx
+++ b/src/pages/Boats.tsx
@@ -304,7 +304,7 @@ export default function Boats() {
       </Card>
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
         <Card>
           <CardContent className="p-3 sm:p-4 text-center">
             <div className="text-xl sm:text-2xl font-bold text-green-600">{stats.available}</div>


### PR DESCRIPTION
## Summary
- show boats stats in one column on small screens, two columns on small devices, four on large

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js' / 403 installing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_688f14d67c70832dae2e9e64fdfc7e07