### PR TITLE
Adjust order details grid layout for small screens

### DIFF
--- a/src/components/orders/OrderDetailsDialog.tsx
+++ b/src/components/orders/OrderDetailsDialog.tsx
@@ -252,7 +252,7 @@ export function OrderDetailsDialog({ order, isOpen, onClose }: OrderDetailsDialo
 
             <div className="space-y-6">
           {/* Informations générales */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
             <Card>
               <CardContent className="p-4">
                 <div className="flex items-center gap-2 mb-2">


### PR DESCRIPTION
## Summary
- refine OrderDetailsDialog grid layout to span 1 column by default and 2 columns on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/corailcaraibes/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_688f14d8ba70832d9a775209bb9f93f6