### PR TITLE
feat: enable deleting maintenance interventions

### DIFF
--- a/src/components/maintenance/InterventionCards.tsx
+++ b/src/components/maintenance/InterventionCards.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Edit, Eye, Clock, User, Calendar, Wrench } from 'lucide-react';
+import { Edit, Eye, Clock, User, Calendar, Wrench, Trash2 } from 'lucide-react';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -11,6 +11,7 @@ interface InterventionCardsProps {
   onEdit: (intervention: Intervention) => void;
   canManage: boolean;
   showHistory?: boolean;
+  onDelete?: (intervention: Intervention) => void;
 }
 
 const statusColors = {
@@ -34,12 +35,13 @@ const statusIcons = {
   cancelled: Clock
 };
 
-export function InterventionCards({ 
-  interventions, 
-  isLoading, 
-  onEdit, 
-  canManage, 
-  showHistory = false 
+export function InterventionCards({
+  interventions,
+  isLoading,
+  onEdit,
+  canManage,
+  showHistory = false,
+  onDelete
 }: InterventionCardsProps) {
   if (isLoading) {
     return (
@@ -165,6 +167,22 @@ export function InterventionCards({
                     <Edit className="h-4 w-4 mr-1" />
                     Modifier
                   </Button>
+                  {onDelete && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (window.confirm('Êtes-vous sûr de vouloir supprimer cette intervention ?')) {
+                          onDelete(intervention);
+                        }
+                      }}
+                      className="hover:bg-background text-red-600 hover:text-red-700"
+                    >
+                      <Trash2 className="h-4 w-4 mr-1" />
+                      Supprimer
+                    </Button>
+                  )}
                 </div>
               </CardFooter>
             )}

--- a/src/components/maintenance/MaintenanceInterventions.tsx
+++ b/src/components/maintenance/MaintenanceInterventions.tsx
@@ -9,10 +9,12 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { InterventionCards } from '@/components/maintenance/InterventionCards';
 import { InterventionDialog } from '@/components/maintenance/InterventionDialog';
 import { Intervention } from '@/types';
+import { useToast } from '@/hooks/use-toast';
 
 export function MaintenanceInterventions() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
+  const { toast } = useToast();
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedStatus, setSelectedStatus] = useState('all');
   const [selectedBoat, setSelectedBoat] = useState('all');
@@ -99,6 +101,32 @@ export function MaintenanceInterventions() {
     queryClient.invalidateQueries({ queryKey: ['interventions'] });
   };
 
+  const handleDelete = async (intervention: Intervention) => {
+    if (!window.confirm('Êtes-vous sûr de vouloir supprimer cette intervention ?')) {
+      return;
+    }
+
+    const { error } = await supabase
+      .from('interventions')
+      .delete()
+      .eq('id', intervention.id);
+
+    if (error) {
+      console.error('Error deleting intervention:', error);
+      toast({
+        title: 'Erreur',
+        description: "Impossible de supprimer l'intervention.",
+        variant: 'destructive',
+      });
+    } else {
+      toast({
+        title: 'Intervention supprimée',
+        description: "L'intervention a été supprimée avec succès.",
+      });
+      queryClient.invalidateQueries({ queryKey: ['interventions'] });
+    }
+  };
+
   const canManage = user?.role === 'direction' || user?.role === 'chef_base';
 
   return (
@@ -169,6 +197,7 @@ export function MaintenanceInterventions() {
             isLoading={isLoading}
             onEdit={handleEdit}
             canManage={canManage}
+            onDelete={handleDelete}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add delete support to maintenance cards
- allow deleting interventions with confirmation and toast feedback

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm install` (fails: ERESOLVE could not resolve)


------
https://chatgpt.com/codex/tasks/task_e_6893790eaf1c832d994c107205801b35