### PR TITLE
feat: track boat HIN and hull numbers

### DIFF
--- a/src/components/boats/BoatDialog.tsx
+++ b/src/components/boats/BoatDialog.tsx
@@ -34,7 +34,8 @@ export function BoatDialog({ isOpen, onClose, boat }: BoatDialogProps) {
   const [formData, setFormData] = useState({
     name: '',
     model: '',
-    serialNumber: '',
+    hin: '',
+    hullNumber: '',
     year: new Date().getFullYear(),
     status: 'available' as 'available' | 'rented' | 'maintenance' | 'out_of_service',
     baseId: '',
@@ -59,7 +60,8 @@ export function BoatDialog({ isOpen, onClose, boat }: BoatDialogProps) {
         setFormData({
           name: boat.name,
           model: boat.model,
-          serialNumber: boat.serialNumber,
+          hin: boat.hin,
+          hullNumber: boat.hullNumber || '',
           year: boat.year,
           status: boat.status,
           baseId: boat.baseId,
@@ -69,7 +71,8 @@ export function BoatDialog({ isOpen, onClose, boat }: BoatDialogProps) {
         setFormData({
           name: '',
           model: '',
-          serialNumber: '',
+          hin: '',
+          hullNumber: '',
           year: new Date().getFullYear(),
           status: 'available',
           baseId: user?.baseId || '',
@@ -87,7 +90,8 @@ export function BoatDialog({ isOpen, onClose, boat }: BoatDialogProps) {
       const boatData = {
         name: formData.name,
         model: formData.model,
-        serial_number: formData.serialNumber,
+        hin: formData.hin,
+        hull_number: formData.hullNumber || null,
         year: formData.year,
         status: formData.status,
         base_id: formData.baseId,
@@ -177,13 +181,24 @@ export function BoatDialog({ isOpen, onClose, boat }: BoatDialogProps) {
           </div>
 
           <div>
-            <Label htmlFor="serialNumber" className="text-sm">Numéro de série *</Label>
+            <Label htmlFor="hin" className="text-sm">N° HIN *</Label>
             <Input
-              id="serialNumber"
-              value={formData.serialNumber}
-              onChange={(e) => setFormData(prev => ({ ...prev, serialNumber: e.target.value }))}
-              placeholder="Ex: LAG380-2020-001"
+              id="hin"
+              value={formData.hin}
+              onChange={(e) => setFormData(prev => ({ ...prev, hin: e.target.value }))}
+              placeholder="Ex: FR-HIN123456789"
               required
+              className="text-sm"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="hullNumber" className="text-sm">N° de coque</Label>
+            <Input
+              id="hullNumber"
+              value={formData.hullNumber}
+              onChange={(e) => setFormData(prev => ({ ...prev, hullNumber: e.target.value }))}
+              placeholder="Ex: LAG380-2020-001"
               className="text-sm"
             />
           </div>
@@ -257,7 +272,7 @@ export function BoatDialog({ isOpen, onClose, boat }: BoatDialogProps) {
             <Button type="button" variant="outline" onClick={onClose} disabled={loading} size="sm" className="text-sm">
               Annuler
             </Button>
-            <Button type="submit" disabled={loading || !formData.name || !formData.model || !formData.serialNumber || !formData.baseId} size="sm" className="text-sm">
+            <Button type="submit" disabled={loading || !formData.name || !formData.model || !formData.hin || !formData.baseId} size="sm" className="text-sm">
               {loading ? 'Sauvegarde...' : boat ? 'Modifier' : 'Créer'}
             </Button>
           </div>

--- a/src/components/boats/BoatHistoryDialog.tsx
+++ b/src/components/boats/BoatHistoryDialog.tsx
@@ -242,8 +242,13 @@ export function BoatHistoryDialog({ isOpen, onClose, boat }: BoatHistoryDialogPr
                     <span className="font-medium">Année:</span> {boat.year}
                   </div>
                   <div>
-                    <span className="font-medium">N° série:</span> {boat.serialNumber}
+                    <span className="font-medium">N° HIN:</span> {boat.hin}
                   </div>
+                  {boat.hullNumber && (
+                    <div>
+                      <span className="font-medium">N° de coque:</span> {boat.hullNumber}
+                    </div>
+                  )}
                   <div>
                     <span className="font-medium">Statut:</span> {boat.status}
                   </div>

--- a/src/components/checkin/BoatRentalSelector.tsx
+++ b/src/components/checkin/BoatRentalSelector.tsx
@@ -66,7 +66,7 @@ export function BoatRentalSelector({ type, onBoatSelect, onRentalDataChange }: B
           .select(`
             id,
             boat_id,
-            boats!inner(id, name, model, serial_number, year, status, base_id)
+            boats!inner(id, name, model, hin, hull_number, year, status, base_id)
           `)
           .eq('status', 'confirmed');
 
@@ -185,7 +185,10 @@ export function BoatRentalSelector({ type, onBoatSelect, onRentalDataChange }: B
               <div className="grid grid-cols-2 gap-2 text-sm text-gray-600">
                 <div>Modèle: {selectedBoat.model}</div>
                 <div>Année: {selectedBoat.year}</div>
-                <div>N° Série: {selectedBoat.serial_number}</div>
+                <div>N° HIN: {selectedBoat.hin}</div>
+                {selectedBoat.hull_number && (
+                  <div>N° de coque: {selectedBoat.hull_number}</div>
+                )}
                 <div>Statut: <Badge variant={selectedBoat.status === 'available' ? 'default' : 'secondary'}>
                   {selectedBoat.status === 'available' ? 'Disponible' : 'En location'}
                 </Badge></div>

--- a/src/components/checkin/ChecklistForm.tsx
+++ b/src/components/checkin/ChecklistForm.tsx
@@ -318,7 +318,7 @@ export function ChecklistForm({ boat, rentalData, type, onComplete }: ChecklistF
             {type === 'checkin' ? 'Check-in' : 'Check-out'} - {boat.name}
           </span>
           <div className="text-sm text-muted-foreground">
-            {boat.model} • {boat.serial_number}
+            {boat.model} • {boat.hin}
           </div>
         </CardTitle>
       </CardHeader>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -426,7 +426,8 @@ export type Database = {
           model: string
           name: string
           next_maintenance: string | null
-          serial_number: string
+          hin: string
+          hull_number: string | null
           status: Database["public"]["Enums"]["boat_status"] | null
           updated_at: string | null
           year: number
@@ -439,7 +440,8 @@ export type Database = {
           model: string
           name: string
           next_maintenance?: string | null
-          serial_number: string
+          hin: string
+          hull_number?: string | null
           status?: Database["public"]["Enums"]["boat_status"] | null
           updated_at?: string | null
           year: number
@@ -452,7 +454,8 @@ export type Database = {
           model?: string
           name?: string
           next_maintenance?: string | null
-          serial_number?: string
+          hin?: string
+          hull_number?: string | null
           status?: Database["public"]["Enums"]["boat_status"] | null
           updated_at?: string | null
           year?: number

--- a/src/pages/BoatDetails.tsx
+++ b/src/pages/BoatDetails.tsx
@@ -104,9 +104,15 @@ export const BoatDetails = () => {
               <p className="text-lg">{boat.year}</p>
             </div>
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Numéro de série</p>
-              <p className="text-lg">{boat.serial_number}</p>
+              <p className="text-sm font-medium text-muted-foreground">N° HIN</p>
+              <p className="text-lg">{boat.hin}</p>
             </div>
+            {boat.hull_number && (
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">N° de coque</p>
+                <p className="text-lg">{boat.hull_number}</p>
+              </div>
+            )}
             {boat.next_maintenance && (
               <div>
                 <p className="text-sm font-medium text-muted-foreground">Prochaine maintenance</p>

--- a/src/pages/Boats.tsx
+++ b/src/pages/Boats.tsx
@@ -54,7 +54,7 @@ const BoatCard = ({ boat, onEdit, onDelete, onHistory, onMaintenance }: BoatCard
         <div>
           <h3 className="text-lg font-semibold">{boat.name}</h3>
           <p className="text-gray-600">{boat.model} ({boat.year})</p>
-          <p className="text-sm text-gray-500">N° série: {boat.serial_number}</p>
+          <p className="text-sm text-gray-500">N° HIN: {boat.hin}</p>
         </div>
         {getStatusBadge(boat.status)}
       </div>
@@ -183,15 +183,28 @@ export const Boats = () => {
     const matchesSearch = !searchTerm || 
       boat.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
       boat.model.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      boat.serial_number.toLowerCase().includes(searchTerm.toLowerCase());
+      boat.hin.toLowerCase().includes(searchTerm.toLowerCase());
     
     const matchesStatus = filterStatus === 'all' || boat.status === filterStatus;
     
     return matchesSearch && matchesStatus;
   }) || [];
 
-  const handleEdit = (boat: Boat) => {
-    setSelectedBoat(boat);
+  const handleEdit = (boat: any) => {
+    setSelectedBoat({
+      id: boat.id,
+      name: boat.name,
+      model: boat.model,
+      hin: boat.hin,
+      hullNumber: boat.hull_number,
+      year: boat.year,
+      status: boat.status,
+      baseId: boat.base_id,
+      documents: boat.documents,
+      nextMaintenance: boat.next_maintenance,
+      createdAt: boat.created_at,
+      updatedAt: boat.updated_at,
+    });
     setIsDialogOpen(true);
   };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,7 +22,8 @@ export interface Boat {
   id: string;
   name: string;
   model: string;
-  serialNumber: string;
+  hin: string;
+  hullNumber?: string;
   year: number;
   status: 'available' | 'rented' | 'maintenance' | 'out_of_service';
   baseId: string;

--- a/supabase/functions/send-checklist-report/index.ts
+++ b/supabase/functions/send-checklist-report/index.ts
@@ -41,7 +41,7 @@ const handler = async (req: Request): Promise<Response> => {
       .from('boat_checklists')
       .select(`
         *,
-        boats(name, model, serial_number),
+        boats(name, model, hin, hull_number),
         profiles(name, email),
         boat_checklist_items(
           *,

--- a/supabase/migrations/20250807164355_rename_serial_number_to_hin.sql
+++ b/supabase/migrations/20250807164355_rename_serial_number_to_hin.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.boats RENAME COLUMN serial_number TO hin;
+ALTER TABLE public.boats ADD COLUMN hull_number TEXT;


### PR DESCRIPTION
## Summary
- rename `boats.serial_number` to `hin` and add `hull_number`
- expose `hin` and `hull_number` in Supabase and frontend types
- display HIN and hull number on boat pages and dialogs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6894d6e59bd4832d896b68f469d3ccf0