### PR TITLE
Increase compact WeatherWidget height

### DIFF
--- a/src/components/weather/WeatherWidget.tsx
+++ b/src/components/weather/WeatherWidget.tsx
@@ -210,7 +210,7 @@ const WeatherWidget: React.FC<WeatherWidgetProps> = ({ compact = false }) => {
 
   if (compact) {
     return (
-      <Card className="h-16">
+      <Card className="h-auto min-h-[5rem]">
         <CardContent className="p-4 flex items-center justify-between w-full">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- allow more vertical space in compact WeatherWidget by using min-h-[5rem]

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689e2bc09ca8832daceae99e0f0beef2