### PR TITLE
Replace offline bar with header status icon

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,11 +5,10 @@ import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Badge } from '@/components/ui/badge';
-import { Bell, LogOut, Settings, User } from 'lucide-react';
+import { LogOut, Settings, User } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { NotificationDropdown } from '@/components/notifications/NotificationDropdown';
-import { SyncStatusIndicator } from '@/components/ui/sync-status-indicator';
-import { OfflineIndicator } from '@/components/ui/offline-indicator';
+import { OfflineStatusIcon } from '@/components/OfflineStatusIcon';
 export const Header = () => {
   const {
     user,
@@ -40,7 +39,7 @@ export const Header = () => {
         return role;
     }
   };
-  return <header className="h-12 sm:h-14 lg:h-16 border-b border-gray-200 flex items-center justify-between px-2 sm:px-4 lg:px-6 shadow-sm bg-marine-50">
+  return <header className="relative h-12 sm:h-14 lg:h-16 border-b border-gray-200 flex items-center justify-between px-2 sm:px-4 lg:px-6 shadow-sm bg-marine-50">
       <div className="flex items-center gap-1 sm:gap-2 lg:gap-4 min-w-0 flex-1">
         <SidebarTrigger className="text-marine-600 hover:text-marine-700 flex-shrink-0" />
         <div className="flex items-center gap-1 sm:gap-2 lg:gap-3 min-w-0">
@@ -52,8 +51,6 @@ export const Header = () => {
       </div>
 
       <div className="flex items-center gap-1 sm:gap-2 lg:gap-4 flex-shrink-0">
-        <OfflineIndicator />
-        <SyncStatusIndicator showDetails />
         <NotificationDropdown />
 
         <DropdownMenu>
@@ -87,6 +84,9 @@ export const Header = () => {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+      </div>
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+        <OfflineStatusIcon />
       </div>
     </header>;
 };

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,7 +4,6 @@ import { AppSidebar } from '@/components/AppSidebar';
 import { Header } from '@/components/Header';
 import { useAuth } from '@/contexts/AuthContext';
 import { useMobileCapacitor } from '@/hooks/useMobileCapacitor';
-import { MobileOfflineBar } from '@/components/mobile/MobileOfflineBar';
 import { MobileQuickActions } from '@/components/mobile/MobileQuickActions';
 import { backgroundSyncService } from '@/services/backgroundSync';
 
@@ -34,7 +33,6 @@ export const Layout = ({ children }: LayoutProps) => {
   return (
     <SidebarProvider defaultOpen={false}>
       <div className="min-h-screen flex flex-col sm:flex-row w-full bg-slate-50">
-        <MobileOfflineBar />
         <AppSidebar />
         <div className="flex-1 flex flex-col overflow-hidden min-w-0">
           <Header />

--- a/src/components/OfflineStatusIcon.tsx
+++ b/src/components/OfflineStatusIcon.tsx
@@ -1,0 +1,55 @@
+import { Wifi, WifiOff, CloudOff, Download, AlertTriangle } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useOfflineSync } from '@/hooks/useOfflineSync';
+import { cn } from '@/lib/utils';
+
+export const OfflineStatusIcon = () => {
+  const { syncStatus, performSync } = useOfflineSync();
+
+  const getColor = () => {
+    if (syncStatus.error) return 'text-red-500';
+    if (syncStatus.isSyncing) return 'text-blue-500';
+    if (!syncStatus.isOnline || syncStatus.pendingChanges > 0) return 'text-orange-500';
+    return 'text-green-500';
+  };
+
+  const getIcon = () => {
+    if (syncStatus.error) return <AlertTriangle className="h-5 w-5" />;
+    if (syncStatus.isSyncing) return <Download className="h-5 w-5 animate-pulse" />;
+    if (!syncStatus.isOnline) return <WifiOff className="h-5 w-5" />;
+    if (syncStatus.pendingChanges > 0) return <CloudOff className="h-5 w-5" />;
+    return <Wifi className="h-5 w-5" />;
+  };
+
+  const getMessage = () => {
+    if (syncStatus.error) return `Erreur de synchronisation:\n${syncStatus.error}`;
+    if (!syncStatus.isOnline) return 'Mode hors ligne. Les modifications seront synchronisées à la reconnexion.';
+    if (syncStatus.isSyncing) return 'Synchronisation en cours...';
+    if (syncStatus.pendingChanges > 0) return `${syncStatus.pendingChanges} modification(s) en attente. Appuyez pour synchroniser.`;
+    return `Synchronisé${syncStatus.lastSync ? `\nDernière sync: ${new Date(syncStatus.lastSync).toLocaleString()}` : ''}`;
+  };
+
+  const handleClick = async () => {
+    if (syncStatus.isOnline && syncStatus.pendingChanges > 0 && !syncStatus.isSyncing) {
+      await performSync();
+    }
+  };
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={handleClick}
+            className={cn('p-1 rounded-full', getColor())}
+          >
+            {getIcon()}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <pre className="whitespace-pre-wrap text-xs">{getMessage()}</pre>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -52,17 +52,6 @@
   }
 }
 
-/* Offline indicator styles */
-.offline-bar {
-  background: linear-gradient(45deg, #ff6b35, #f7931e);
-  animation: offline-pulse 2s ease-in-out infinite alternate;
-}
-
-@keyframes offline-pulse {
-  from { opacity: 0.8; }
-  to { opacity: 1; }
-}
-
 /* Sync progress animation */
 .sync-progress {
   background: linear-gradient(90deg, 


### PR DESCRIPTION
## Summary
- replace MobileOfflineBar with compact OfflineStatusIcon
- center status icon in header and remove unused components
- clean up obsolete offline bar styles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')


------
https://chatgpt.com/codex/tasks/task_e_68a32f17d954832dbb8fcc4b65bfe655