### PR TITLE
fix: remove offline prefix when syncing

### DIFF
--- a/src/lib/offlineSync.ts
+++ b/src/lib/offlineSync.ts
@@ -44,7 +44,7 @@ export class OfflineSyncManager {
             }
             
             // Check if record exists locally
-            const existingRecord = await sqliteService.findById(`offline_${tableName}`, record.id as string);
+            const existingRecord = await sqliteService.findById(tableName, record.id as string);
             
             if (existingRecord) {
               // Check for conflicts
@@ -64,13 +64,13 @@ export class OfflineSyncManager {
               }
               
               // Update existing record
-              await sqliteService.update(`offline_${tableName}`, record.id as string, {
+              await sqliteService.update(tableName, record.id as string, {
                 ...record,
                 sync_status: 'synced'
               });
             } else {
               // Insert new record
-              await sqliteService.insert(`offline_${tableName}`, {
+              await sqliteService.insert(tableName, {
                 ...record,
                 sync_status: 'synced'
               });
@@ -140,7 +140,7 @@ export class OfflineSyncManager {
           
           // Update local record sync status
           if (change.operation !== 'DELETE') {
-            await sqliteService.update(`offline_${tableName}`, change.record_id, {
+            await sqliteService.update(tableName, change.record_id, {
               sync_status: 'synced'
             });
           }
@@ -231,9 +231,9 @@ export class OfflineSyncManager {
     try {
       // Count offline records
       for (const table of this.defaultOptions.tables!) {
-        const records = await sqliteService.findAll(`offline_${table}`);
+        const records = await sqliteService.findAll(table);
         stats.totalOfflineRecords += records.length;
-        
+
         // Get last sync time
         stats.lastSyncTimes[table] = await sqliteService.getLastSyncTime(table);
       }


### PR DESCRIPTION
## Summary
- pass raw table names to sqliteService when syncing up/down
- keep offline statistics aligned with new table naming

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: eslint: not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_68a3334db598832da489abad0d8e73bc