### PR TITLE
feat: initialise offline sync at layout

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,6 +5,8 @@ import { Header } from '@/components/Header';
 import { useAuth } from '@/contexts/AuthContext';
 import { useMobileCapacitor } from '@/hooks/useMobileCapacitor';
 import { MobileQuickActions } from '@/components/mobile/MobileQuickActions';
+import { MobileOfflineBar } from '@/components/mobile/MobileOfflineBar';
+import { useOfflineSync } from '@/hooks/useOfflineSync';
 import { backgroundSyncService } from '@/services/backgroundSync';
 
 interface LayoutProps {
@@ -14,6 +16,8 @@ interface LayoutProps {
 export const Layout = ({ children }: LayoutProps) => {
   const { isAuthenticated } = useAuth();
   const { isNative } = useMobileCapacitor();
+  // Initialize offline sync (SQLite DB setup & auto-sync when back online)
+  useOfflineSync();
 
   useEffect(() => {
     // Add mobile-specific classes
@@ -32,6 +36,7 @@ export const Layout = ({ children }: LayoutProps) => {
   // Pour les pages authentifiées, on affiche le layout complet
   return (
     <SidebarProvider defaultOpen={false}>
+      <MobileOfflineBar />
       <div className="min-h-screen flex flex-col sm:flex-row w-full bg-slate-50">
         <AppSidebar />
         <div className="flex-1 flex flex-col overflow-hidden min-w-0">


### PR DESCRIPTION
## Summary
- integrate useOfflineSync at app layout to init SQLite and sync when back online
- show MobileOfflineBar to indicate offline status

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a333511830832d9e4fd2b331e9bd87