### PR TITLE
fix: include engine components in dashboard KPIs

### DIFF
--- a/src/pages/BoatsDashboard.tsx
+++ b/src/pages/BoatsDashboard.tsx
@@ -67,8 +67,7 @@ export const BoatsDashboard = () => {
   // Fetch boat components for engine data
   const { data: boatComponents = [], loading: componentsLoading, error: componentsError } = useOfflineData<any>({
     table: 'boat_components',
-    baseId: user?.role !== 'direction' ? user?.baseId : undefined,
-    dependencies: [user?.id, user?.role]
+    dependencies: [user?.id, user?.role, user?.baseId]
   });
 
   // Debug data loading states


### PR DESCRIPTION
## Summary
- fetch boat components without base filter so technicians and base managers see engine data
- refresh component data when user/base changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `bun scripts/kpi-test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aa07b7a84c832d8309c5f2a229e86c