### PR TITLE
Invalidate interventions query after task creation

### DIFF
--- a/src/components/maintenance/GanttMaintenanceSchedule.tsx
+++ b/src/components/maintenance/GanttMaintenanceSchedule.tsx
@@ -1003,6 +1003,9 @@ export function GanttMaintenanceSchedule() {
             setSelectedTask(null);
           }}
           technicians={technicians}
+          onTaskCreated={() =>
+            queryClient.invalidateQueries({ queryKey: ['gantt-interventions'] })
+          }
         />
       )}
 


### PR DESCRIPTION
## Summary
- Reload gantt interventions after creating a task by invalidating the related query

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden when fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68aa07856e1c832d915322c547c78e1c