### PR TITLE
feat: make maintenance history date filter optional

### DIFF
--- a/src/components/maintenance/MaintenanceHistory.tsx
+++ b/src/components/maintenance/MaintenanceHistory.tsx
@@ -1,24 +1,20 @@
 import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Search, Filter, Calendar } from 'lucide-react';
+import { Search } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { InterventionTable } from '@/components/maintenance/InterventionTable';
-import { DatePickerWithRange } from '@/components/ui/date-range-picker';
-import { addDays } from 'date-fns';
+import { DatePickerWithRange, type DateRange } from '@/components/ui/date-range-picker';
 
 export function MaintenanceHistory() {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedStatus, setSelectedStatus] = useState('all');
   const [selectedBoat, setSelectedBoat] = useState('all');
-  const [dateRange, setDateRange] = useState({
-    from: addDays(new Date(), -30),
-    to: new Date()
-  });
+  const [dateRange, setDateRange] = useState<DateRange | undefined>();
 
   const { data: interventions = [], isLoading } = useQuery({
-    queryKey: ['interventions-history', dateRange],
+    queryKey: ['interventions-history', dateRange?.from, dateRange?.to],
     queryFn: async () => {
       let query = supabase
         .from('interventions')
@@ -29,11 +25,17 @@ export function MaintenanceHistory() {
         `)
         .order('completed_date', { ascending: false });
 
-      if (dateRange.from) {
-        query = query.gte('completed_date', dateRange.from.toISOString().split('T')[0]);
+      if (dateRange?.from) {
+        query = query.gte(
+          'completed_date',
+          dateRange.from.toISOString().split('T')[0]
+        );
       }
-      if (dateRange.to) {
-        query = query.lte('completed_date', dateRange.to.toISOString().split('T')[0]);
+      if (dateRange?.to) {
+        query = query.lte(
+          'completed_date',
+          dateRange.to.toISOString().split('T')[0]
+        );
       }
 
       const { data, error } = await query;

--- a/src/components/ui/date-range-picker.tsx
+++ b/src/components/ui/date-range-picker.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
-import { Calendar, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Calendar } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 
-interface DateRange {
-  from: Date;
-  to: Date;
+export interface DateRange {
+  from?: Date;
+  to?: Date;
 }
 
 interface DatePickerWithRangeProps {
-  date: DateRange;
+  date?: DateRange;
   onDateChange: (range: DateRange) => void;
   placeholder?: string;
 }
@@ -32,7 +32,7 @@ export function DatePickerWithRange({ date, onDateChange, placeholder = "Sélect
           variant="outline"
           className={cn(
             "w-full justify-start text-left font-normal",
-            !date && "text-muted-foreground"
+            (!date?.from && !date?.to) && "text-muted-foreground"
           )}
         >
           <Calendar className="mr-2 h-4 w-4" />
@@ -98,11 +98,13 @@ export function DatePickerWithRange({ date, onDateChange, placeholder = "Sélect
             </Button>
           </div>
         </div>
-        <div className="p-3">
-          <div className="text-sm text-gray-500">
-            Période actuelle: {format(date.from, "dd/MM/yyyy", { locale: fr })} - {format(date.to, "dd/MM/yyyy", { locale: fr })}
+        {date?.from && date?.to && (
+          <div className="p-3">
+            <div className="text-sm text-gray-500">
+              Période actuelle: {format(date.from, "dd/MM/yyyy", { locale: fr })} - {format(date.to, "dd/MM/yyyy", { locale: fr })}
+            </div>
           </div>
-        </div>
+        )}
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION
## Summary
- allow querying maintenance history without default 30‑day range
- support undefined date ranges in shared picker

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68aab44ccb50832d9ea56d6cfd3849d7