### PR TITLE
feat: display boat name in maintenance history

### DIFF
--- a/src/components/maintenance/InterventionTable.tsx
+++ b/src/components/maintenance/InterventionTable.tsx
@@ -105,8 +105,7 @@ export function InterventionTable({
               </TableCell>
               <TableCell>
                 <div className="text-sm">
-                  {/* {intervention.boats?.name} */}
-                  Bateau #{intervention.boatId.slice(0, 8)}
+                  {intervention.boat?.name}
                 </div>
               </TableCell>
               <TableCell>

--- a/src/components/maintenance/MaintenanceHistory.tsx
+++ b/src/components/maintenance/MaintenanceHistory.tsx
@@ -42,6 +42,7 @@ export function MaintenanceHistory() {
       return data.map(intervention => ({
         id: intervention.id,
         boatId: intervention.boat_id || '',
+        boat: intervention.boats,
         technicianId: intervention.technician_id || '',
         title: intervention.title,
         description: intervention.description || '',


### PR DESCRIPTION
## Summary
- map boat details from interventions history query
- show boat name in maintenance table

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68aab44dbfb8832d9ee1443be0628cb2