### PR TITLE
Include technician details in maintenance interventions

### DIFF
--- a/src/components/maintenance/InterventionTable.tsx
+++ b/src/components/maintenance/InterventionTable.tsx
@@ -112,8 +112,7 @@ export function InterventionTable({
               <TableCell>
                 <div className="flex items-center gap-1 text-sm">
                   <User className="h-3 w-3" />
-                  {/* {intervention.profiles?.name || 'Non assigné'} */}
-                  Technicien
+                  {intervention.technician?.name || 'Non assigné'}
                 </div>
               </TableCell>
               <TableCell>

--- a/src/components/maintenance/MaintenanceHistory.tsx
+++ b/src/components/maintenance/MaintenanceHistory.tsx
@@ -43,6 +43,7 @@ export function MaintenanceHistory() {
         id: intervention.id,
         boatId: intervention.boat_id || '',
         technicianId: intervention.technician_id || '',
+        technician: intervention.profiles,
         title: intervention.title,
         description: intervention.description || '',
         status: intervention.status || 'scheduled',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -151,6 +151,9 @@ export interface Intervention {
     name: string;
     model: string;
   };
+  technician?: {
+    name: string;
+  };
 }
 
 export interface ChecklistItem {


### PR DESCRIPTION
## Summary
- Map technician profile data into maintenance history records
- Extend Intervention type with optional technician information
- Display technician name dynamically in intervention table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; dependency installation failed: 403 Forbidden for date-fns)*

------
https://chatgpt.com/codex/tasks/task_e_68aab44e7760832da0448240dad65128