### PR TITLE
Use intervention id to detect edit mode

### DIFF
--- a/src/components/maintenance/InterventionDialog.tsx
+++ b/src/components/maintenance/InterventionDialog.tsx
@@ -148,7 +148,7 @@ export function InterventionDialog({ isOpen, onClose, intervention }: Interventi
   });
 
   useEffect(() => {
-    if (intervention) {
+    if (intervention?.id) {
       form.reset({
         title: intervention.title,
         description: intervention.description,
@@ -177,7 +177,7 @@ export function InterventionDialog({ isOpen, onClose, intervention }: Interventi
 
   // Separate effect for handling existing parts to avoid infinite loop
   useEffect(() => {
-    if (intervention && existingParts.length > 0) {
+    if (intervention?.id && existingParts.length > 0) {
       setInterventionParts(existingParts);
     }
   }, [intervention, existingParts]);
@@ -214,7 +214,7 @@ export function InterventionDialog({ isOpen, onClose, intervention }: Interventi
 
       let interventionId: string;
 
-      if (intervention && intervention.id && intervention.id.trim() !== '') {
+      if (intervention?.id && intervention.id.trim() !== '') {
         // Update existing intervention
         const { error } = await supabase
           .from('interventions')
@@ -301,8 +301,8 @@ export function InterventionDialog({ isOpen, onClose, intervention }: Interventi
       }
 
       toast({
-        title: intervention ? "Intervention modifiée" : "Intervention créée",
-        description: intervention 
+        title: intervention?.id ? "Intervention modifiée" : "Intervention créée",
+        description: intervention?.id 
           ? "L'intervention a été mise à jour avec succès."
           : "La nouvelle intervention a été programmée."
       });
@@ -337,10 +337,10 @@ export function InterventionDialog({ isOpen, onClose, intervention }: Interventi
       <DialogContent className="w-[95vw] sm:max-w-[600px] max-h-[90vh] overflow-y-auto mx-auto" aria-describedby="intervention-dialog-description">
         <DialogHeader>
           <DialogTitle>
-            {intervention ? 'Modifier l\'intervention' : 'Nouvelle intervention'}
+            {intervention?.id ? 'Modifier l\'intervention' : 'Nouvelle intervention'}
           </DialogTitle>
           <p id="intervention-dialog-description" className="text-sm text-muted-foreground">
-            {intervention ? 'Modifier les détails de l\'intervention existante' : 'Créer une nouvelle intervention de maintenance'}
+            {intervention?.id ? 'Modifier les détails de l\'intervention existante' : 'Créer une nouvelle intervention de maintenance'}
           </p>
         </DialogHeader>
 
@@ -519,7 +519,7 @@ export function InterventionDialog({ isOpen, onClose, intervention }: Interventi
                 disabled={isSubmitting}
                 className="bg-marine-600 hover:bg-marine-700"
               >
-                {isSubmitting ? 'Sauvegarde...' : (intervention ? 'Modifier' : 'Créer')}
+                {isSubmitting ? 'Sauvegarde...' : (intervention?.id ? 'Modifier' : 'Créer')}
               </Button>
             </div>
           </form>


### PR DESCRIPTION
## Summary
- use `intervention?.id` instead of `intervention` when determining edit vs create
- update dialog title, description, toast messaging, and submit button
- reset form and parts only when no intervention id is present

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68aab5fc0b38832d9c83068c5c29e79d