### PR TITLE
feat: add PageShell wrapper for layouts

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import { MobileQuickActions } from '@/components/mobile/MobileQuickActions';
 import { MobileOfflineBar } from '@/components/mobile/MobileOfflineBar';
 import { useOfflineSync } from '@/hooks/useOfflineSync';
 import { backgroundSyncService } from '@/services/backgroundSync';
+import { PageShell } from '@/components/layout/PageShell';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -37,16 +38,18 @@ export const Layout = ({ children }: LayoutProps) => {
   return (
     <SidebarProvider defaultOpen={false}>
       <MobileOfflineBar />
-      <div className="min-h-screen flex flex-col sm:flex-row w-full bg-slate-50">
-        <AppSidebar />
-        <div className="flex-1 flex flex-col overflow-hidden min-w-0">
-          <Header />
-          <main className="flex-1 overflow-y-auto p-2 sm:p-4 lg:p-6">
-            {children}
-          </main>
+      <PageShell>
+        <div className="flex flex-col sm:flex-row w-full bg-slate-50">
+          <AppSidebar />
+          <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+            <Header />
+            <main className="flex-1 overflow-y-auto p-2 sm:p-4 lg:p-6">
+              {children}
+            </main>
+          </div>
+          <MobileQuickActions />
         </div>
-        <MobileQuickActions />
-      </div>
+      </PageShell>
     </SidebarProvider>
   );
 };

--- a/src/components/layout/PageShell.tsx
+++ b/src/components/layout/PageShell.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-[100dvh] flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add PageShell component to handle viewport height and safe-area padding
- update Layout to wrap sidebar/header in PageShell while preserving behavior

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e2e6684832d82cdaf04bd207b53