### PR TITLE
refactor auth page layout

### DIFF
--- a/src/components/ui/page-shell.tsx
+++ b/src/components/ui/page-shell.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface PageShellProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function PageShell({ children, className }: PageShellProps) {
+  return (
+    <div className={cn('min-h-screen p-4 sm:p-6', className)}>
+      {children}
+    </div>
+  );
+}
+
+export default PageShell;

--- a/src/components/ui/responsive-image.tsx
+++ b/src/components/ui/responsive-image.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface ResponsiveImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {}
+
+export function ResponsiveImage({ className, ...props }: ResponsiveImageProps) {
+  return <img {...props} className={cn('h-auto w-full', className)} />;
+}
+
+export default ResponsiveImage;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -12,6 +12,8 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 import { secureStorage } from '@/lib/storage';
+import { PageShell } from '@/components/ui/page-shell';
+import { ResponsiveImage } from '@/components/ui/responsive-image';
 export default function Auth() {
   const {
     isAuthenticated
@@ -147,10 +149,10 @@ export default function Auth() {
       setLoading(false);
     }
   };
-  return <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-marine-500 to-ocean-500 p-4">
+  return <PageShell className="flex items-center justify-center bg-gradient-to-br from-marine-500 to-ocean-500">
       <Card className="w-full max-w-md rounded-lg">
         <CardHeader className="text-center">
-          <img src={authLogo} alt="Corail Caraibes logo" className="w-50 h-50 object-contain rounded-lg mx-auto mb-4" />
+          <ResponsiveImage className="mx-auto mb-4 aspect-square w-full max-w-[80px]" src={authLogo} alt="Corail Caraibes logo" />
           <CardTitle className="text-2xl">Corail Caraibes</CardTitle>
           <CardDescription>Gestionnaire de flotte</CardDescription>
         </CardHeader>
@@ -261,5 +263,5 @@ export default function Auth() {
           </Tabs>
         </CardContent>
       </Card>
-    </div>;
+    </PageShell>;
 }


### PR DESCRIPTION
## Summary
- add PageShell wrapper with responsive padding
- implement ResponsiveImage and use it for auth logo
- refactor Auth page to use PageShell and spacing utilities

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ab4e2fff1c832dbafe4a8e0b50ffe8