### PR TITLE
fix: use dynamic viewport height for auth pages

### DIFF
--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface PageShellProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const PageShell = ({ children, className }: PageShellProps) => {
+  return <div className={cn(className)}>{children}</div>;
+};
+

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -12,6 +12,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 import { secureStorage } from '@/lib/storage';
+import { PageShell } from '@/components/PageShell';
 export default function Auth() {
   const {
     isAuthenticated
@@ -147,7 +148,7 @@ export default function Auth() {
       setLoading(false);
     }
   };
-  return <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-marine-500 to-ocean-500 p-4">
+  return <PageShell className="min-h-[100dvh] flex items-center justify-center bg-gradient-to-br from-marine-500 to-ocean-500 p-4">
       <Card className="w-full max-w-md rounded-lg">
         <CardHeader className="text-center">
           <img src={authLogo} alt="Corail Caraibes logo" className="w-50 h-50 object-contain rounded-lg mx-auto mb-4" />
@@ -261,5 +262,5 @@ export default function Auth() {
           </Tabs>
         </CardContent>
       </Card>
-    </div>;
+    </PageShell>;
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -9,6 +9,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Loader2, Ship } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
+import { PageShell } from '@/components/PageShell';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -39,7 +40,7 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4 gradient-ocean wave-pattern">
+    <PageShell className="min-h-[100dvh] flex items-center justify-center p-4 gradient-ocean wave-pattern">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center w-16 h-16 bg-white rounded-full mb-4 shadow-lg">
@@ -69,7 +70,7 @@ export default function Login() {
                   required
                 />
               </div>
-              
+
               <div className="space-y-2">
                 <Label htmlFor="password">Mot de passe</Label>
                 <Input
@@ -107,6 +108,6 @@ export default function Login() {
           </CardContent>
         </Card>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { PageShell } from '@/components/PageShell';
 
 const NotFound = () => {
   const location = useLocation();
@@ -12,7 +13,7 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <PageShell className="min-h-[100dvh] flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
@@ -20,7 +21,7 @@ const NotFound = () => {
           Return to Home
         </a>
       </div>
-    </div>
+    </PageShell>
   );
 };
 


### PR DESCRIPTION
## Summary
- add PageShell wrapper for pages bypassing Layout
- ensure login, auth and 404 pages use `min-h-[100dvh]`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e30df08832d86ceebf69819f315