### PR TITLE
refactor: make planning grid responsive

### DIFF
--- a/src/components/maintenance/planning/TimeGrid.tsx
+++ b/src/components/maintenance/planning/TimeGrid.tsx
@@ -75,7 +75,7 @@ function DroppableTimeSlot({ technicianId, date, timeSlot, activities, onActivit
     <div
       ref={setNodeRef}
       className={`
-        min-h-[60px] max-h-[60px] h-[60px] w-[200px] min-w-[200px] max-w-[200px] border-r border-b border-border p-1 transition-colors overflow-hidden
+        min-h-[60px] max-h-[60px] h-[60px] min-w-0 flex-1 border-r border-b p-1 transition-colors overflow-hidden
         ${isOver ? 'bg-primary/10' : 'bg-background hover:bg-muted/50'}
       `}
     >
@@ -92,7 +92,7 @@ function DroppableTimeSlot({ technicianId, date, timeSlot, activities, onActivit
   );
 }
 
-export function TimeGrid({ 
+export function TimeGrid({
   weekDays, 
   timeSlots, 
   technicians, 
@@ -111,18 +111,20 @@ export function TimeGrid({
               Techniciens
             </div>
             {/* Days */}
-            {weekDays.map((day, dayIndex) => (
-              <div 
-                key={dayIndex} 
-                className={`
-                  min-w-[200px] max-w-[200px] w-[200px] p-2 text-center border-r border-border font-medium
-                  ${isToday(day) ? 'bg-primary/10' : 'bg-muted'}
-                `}
-              >
-                <div className="text-sm">{format(day, 'EEEE', { locale: fr })}</div>
-                <div className="text-lg">{format(day, 'dd MMM', { locale: fr })}</div>
-              </div>
-            ))}
+            <div className="grid flex-1 grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]">
+              {weekDays.map((day, dayIndex) => (
+                <div
+                  key={dayIndex}
+                  className={`
+                    min-w-0 flex-1 p-2 text-center border-r border-b font-medium
+                    ${isToday(day) ? 'bg-primary/10' : 'bg-muted'}
+                  `}
+                >
+                  <div className="text-sm">{format(day, 'EEEE', { locale: fr })}</div>
+                  <div className="text-lg">{format(day, 'dd MMM', { locale: fr })}</div>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
 
@@ -131,7 +133,7 @@ export function TimeGrid({
           {/* Time labels column */}
           <div className="w-48 border-r border-border">
             {timeSlots.map((timeSlot, index) => (
-              <div 
+              <div
                 key={index}
                 className="min-h-[60px] max-h-[60px] h-[60px] border-b border-border p-1 text-xs text-muted-foreground bg-muted/50 flex items-center"
               >
@@ -142,16 +144,16 @@ export function TimeGrid({
 
           {/* Technician columns */}
           {technicians.map((technician) => (
-            <div key={technician.id} className="flex flex-col">
+            <div key={technician.id} className="flex flex-col flex-1">
               {/* Technician header */}
               <div className="sticky top-12 z-10 bg-background border-b p-2 text-center font-medium">
                 {technician.name}
               </div>
 
               {/* Days for this technician */}
-              <div className="flex">
+              <div className="grid flex-1 grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]">
                 {weekDays.map((day, dayIndex) => (
-                  <div key={dayIndex} className="min-w-[200px]">
+                  <div key={dayIndex} className="flex flex-col">
                     {timeSlots.map((timeSlot, slotIndex) => (
                       <DroppableTimeSlot
                         key={slotIndex}


### PR DESCRIPTION
## Summary
- replace fixed 200px widths with flexible grid-driven layout
- mirror responsive styling in days header and technician slots

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e321f40832d9b0169e40545ef4f