### PR TITLE
refactor: add layout primitives

### DIFF
--- a/src/components/layout/AutoGrid.tsx
+++ b/src/components/layout/AutoGrid.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface AutoGridProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Minimum width for each grid item. */
+  minColumnWidth?: string;
+}
+
+/**
+ * Responsive CSS grid that automatically fits items based on the available width.
+ *
+ * @example
+ * ```tsx
+ * import { AutoGrid } from "@/components/layout/AutoGrid";
+ *
+ * export function Example() {
+ *   return (
+ *     <AutoGrid minColumnWidth="16rem">
+ *       <div>Item 1</div>
+ *       <div>Item 2</div>
+ *       <div>Item 3</div>
+ *     </AutoGrid>
+ *   );
+ * }
+ * ```
+ */
+export function AutoGrid({
+  children,
+  minColumnWidth = "16rem",
+  className,
+  style,
+  ...props
+}: AutoGridProps) {
+  return (
+    <div
+      className={cn("grid gap-4", className)}
+      style={{ gridTemplateColumns: `repeat(auto-fit, minmax(${minColumnWidth}, 1fr))`, ...style }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/layout/Container.tsx
+++ b/src/components/layout/Container.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+/**
+ * Centers page content and constrains its maximum width.
+ *
+ * @example
+ * ```tsx
+ * import { Container } from "@/components/layout/Container";
+ *
+ * export function Example() {
+ *   return (
+ *     <Container>
+ *       <p>Your content</p>
+ *     </Container>
+ *   );
+ * }
+ * ```
+ */
+export function Container({ children }: { children: React.ReactNode }) {
+  return <div className="container mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">{children}</div>;
+}

--- a/src/components/layout/ResponsiveImage.tsx
+++ b/src/components/layout/ResponsiveImage.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface ResponsiveImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {}
+
+/**
+ * Displays an image that scales responsively and loads lazily by default.
+ *
+ * @example
+ * ```tsx
+ * import { ResponsiveImage } from "@/components/layout/ResponsiveImage";
+ *
+ * export function Example() {
+ *   return <ResponsiveImage src="/logo.png" alt="Logo" />;
+ * }
+ * ```
+ */
+export function ResponsiveImage({ className, ...props }: ResponsiveImageProps) {
+  return <img loading="lazy" className={cn("w-full h-auto", className)} {...props} />;
+}

--- a/src/components/layout/Stack.tsx
+++ b/src/components/layout/Stack.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface StackProps extends React.HTMLAttributes<HTMLDivElement> {
+  direction?: "row" | "column";
+  gap?: string | number;
+}
+
+/**
+ * Flex container that stacks its children with consistent spacing.
+ *
+ * @example
+ * ```tsx
+ * import { Stack } from "@/components/layout/Stack";
+ *
+ * export function Example() {
+ *   return (
+ *     <Stack gap="1rem">
+ *       <div>Item 1</div>
+ *       <div>Item 2</div>
+ *     </Stack>
+ *   );
+ * }
+ * ```
+ */
+export function Stack({
+  children,
+  direction = "column",
+  gap = "1rem",
+  className,
+  style,
+  ...props
+}: StackProps) {
+  return (
+    <div
+      className={cn("flex", direction === "row" ? "flex-row" : "flex-col", className)}
+      style={{ gap, ...style }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -7,6 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import authLogo from '@/assets/auth-logo.png';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ResponsiveImage } from '@/components/layout/ResponsiveImage';
 import { Checkbox } from '@/components/ui/checkbox';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
@@ -150,7 +151,7 @@ export default function Auth() {
   return <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-marine-500 to-ocean-500 p-4">
       <Card className="w-full max-w-md rounded-lg">
         <CardHeader className="text-center">
-          <img src={authLogo} alt="Corail Caraibes logo" className="w-50 h-50 object-contain rounded-lg mx-auto mb-4" />
+          <ResponsiveImage src={authLogo} alt="Corail Caraibes logo" className="w-50 h-50 object-contain rounded-lg mx-auto mb-4" />
           <CardTitle className="text-2xl">Corail Caraibes</CardTitle>
           <CardDescription>Gestionnaire de flotte</CardDescription>
         </CardHeader>
@@ -260,6 +261,7 @@ export default function Auth() {
             </TabsContent>
           </Tabs>
         </CardContent>
-      </Card>
-    </div>;
+        </Card>
+      </div>
+  );
 }

--- a/src/pages/BoatDetails.tsx
+++ b/src/pages/BoatDetails.tsx
@@ -11,6 +11,7 @@ import { BoatMaintenancePlanner } from '@/components/boats/BoatMaintenancePlanne
 import { BoatDashboard } from '@/components/boats/BoatDashboard';
 import { BoatPurchaseHistory } from '@/components/boats/BoatPurchaseHistory';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
+import { AutoGrid } from '@/components/layout/AutoGrid';
 const BoatDetails = () => {
   const {
     boatId
@@ -69,7 +70,7 @@ const BoatDetails = () => {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <AutoGrid className="gap-4">
             <div>
               <p className="text-sm font-medium text-muted-foreground">Modèle</p>
               <p className="text-lg">{boatWithBase.model}</p>
@@ -96,7 +97,7 @@ const BoatDetails = () => {
               <p className="text-sm font-medium text-muted-foreground">Base</p>
               <p className="text-lg">{boatWithBase.base?.name}</p>
             </div>
-          </div>
+          </AutoGrid>
         </CardContent>
       </Card>
 
@@ -143,8 +144,9 @@ const BoatDetails = () => {
         <TabsContent value="history" className="space-y-6">
           <BoatHistoryContent boatId={boatWithBase.id} />
         </TabsContent>
-      </Tabs>
-    </div>;
+        </Tabs>
+      </div>
+  );
 };
 
 export { BoatDetails };

--- a/src/pages/Boats.tsx
+++ b/src/pages/Boats.tsx
@@ -11,6 +11,7 @@ import { useToast } from '@/hooks/use-toast';
 import { BoatDialog } from '@/components/boats/BoatDialog';
 import { BoatFilters } from '@/components/boats/BoatFilters';
 import { Boat } from '@/types';
+import { AutoGrid } from '@/components/layout/AutoGrid';
 const getStatusBadge = (status: string) => {
   const statusConfig = {
     available: {
@@ -210,19 +211,20 @@ export const Boats = () => {
                 </Button>}
             </div>
           </CardContent>
-        </Card> : <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        </Card> : <AutoGrid className="gap-6">
           {filteredBoats.map(boat => <BoatCard key={boat.id} boat={boat} onEdit={handleEdit} onDelete={handleDelete} onHistory={handleHistory} onMaintenance={handleMaintenance} />)}
-        </div>}
+        </AutoGrid>}
 
-      <BoatDialog 
-        isOpen={isDialogOpen} 
-        onClose={() => {
-          setIsDialogOpen(false);
-          setSelectedBoat(null);
-          // Rafraîchir les données après fermeture du dialog
-          refetchBoats();
-        }} 
-        boat={selectedBoat} 
-      />
-    </div>;
+        <BoatDialog
+          isOpen={isDialogOpen}
+          onClose={() => {
+            setIsDialogOpen(false);
+            setSelectedBoat(null);
+            // Rafraîchir les données après fermeture du dialog
+            refetchBoats();
+          }}
+          boat={selectedBoat}
+        />
+      </div>
+  );
 };

--- a/src/pages/BoatsDashboard.tsx
+++ b/src/pages/BoatsDashboard.tsx
@@ -14,6 +14,7 @@ import { ArrowLeft, Search, Filter } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { calculateOilChangeStatus, getWorstOilChangeStatus } from '@/utils/engineMaintenanceUtils';
 import { countExpiredControls } from '@/utils/safetyControlUtils';
+import { AutoGrid } from '@/components/layout/AutoGrid';
 
 export const BoatsDashboard = () => {
   const { user } = useAuth();
@@ -265,7 +266,7 @@ export const BoatsDashboard = () => {
       <FleetBadgesLegend />
 
       {/* Content Grid */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <AutoGrid className="gap-6">
         {/* Main boats grid */}
         <div className="lg:col-span-2 space-y-4">
           {/* Filters */}
@@ -294,7 +295,7 @@ export const BoatsDashboard = () => {
           </div>
 
           {/* Boats grid */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <AutoGrid className="gap-4">
             {filteredBoats.map((boat) => (
               <BoatFleetCard
                 key={boat.id}
@@ -303,7 +304,7 @@ export const BoatsDashboard = () => {
                 onCreateIntervention={handleCreateIntervention}
               />
             ))}
-          </div>
+          </AutoGrid>
 
           {filteredBoats.length === 0 && (
             <div className="text-center py-12 text-muted-foreground">
@@ -316,7 +317,7 @@ export const BoatsDashboard = () => {
         <div className="lg:col-span-1">
           <MaintenanceAlertsPanel alerts={maintenanceAlerts} />
         </div>
-      </div>
+      </AutoGrid>
 
       {/* Intervention Dialog */}
       <InterventionDialog

--- a/src/pages/SafetyControls.tsx
+++ b/src/pages/SafetyControls.tsx
@@ -12,6 +12,7 @@ import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { SafetyStatusIcon } from '@/components/boats/SafetyStatusIcon';
 import { SafetyStatusLegend } from '@/components/boats/SafetyStatusLegend';
+import { AutoGrid } from '@/components/layout/AutoGrid';
 
 export const SafetyControls = () => {
   const navigate = useNavigate();
@@ -124,7 +125,7 @@ export const SafetyControls = () => {
       ) : (
         <>
           <SafetyStatusLegend />
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <AutoGrid className="gap-6">
             {filteredBoats.map(boat => {
               const base = bases.find((b: any) => b.id === boat.base_id);
               
@@ -162,7 +163,7 @@ export const SafetyControls = () => {
                 </Card>
               );
             })}
-          </div>
+          </AutoGrid>
         </>
       )}
     </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Container } from '@/components/layout/Container';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Settings as SettingsIcon, Building, Users, CheckSquare, Wrench, Package, User } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -52,9 +53,10 @@ export default function Settings() {
     ? tabFromUrl 
     : availableTabs[0]?.id || 'profile';
 
-  return (
-    <div className="container mx-auto py-6 px-4">
-      <div className="mb-6">
+    return (
+      <div className="py-6">
+        <Container>
+        <div className="mb-6">
         <div className="flex items-center gap-3 mb-2">
           <SettingsIcon className="h-8 w-8 text-primary" />
           <h1 className="text-3xl font-bold">Paramètres</h1>
@@ -74,25 +76,26 @@ export default function Settings() {
           ))}
         </TabsList>
 
-        {availableTabs.map((tab) => (
-          <TabsContent key={tab.id} value={tab.id}>
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <tab.icon className="h-5 w-5" />
-                  {tab.label}
-                </CardTitle>
-                <CardDescription>
-                  Configuration des paramètres {tab.label.toLowerCase()}
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <tab.component />
-              </CardContent>
-            </Card>
-          </TabsContent>
-        ))}
-      </Tabs>
-    </div>
-  );
-}
+          {availableTabs.map((tab) => (
+            <TabsContent key={tab.id} value={tab.id}>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <tab.icon className="h-5 w-5" />
+                    {tab.label}
+                  </CardTitle>
+                  <CardDescription>
+                    Configuration des paramètres {tab.label.toLowerCase()}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <tab.component />
+                </CardContent>
+              </Card>
+            </TabsContent>
+          ))}
+        </Tabs>
+        </Container>
+      </div>
+    );
+  }

--- a/src/pages/Suppliers.tsx
+++ b/src/pages/Suppliers.tsx
@@ -9,6 +9,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Stack } from '@/components/layout/Stack';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { SupplierDialog } from '@/components/suppliers/SupplierDialog';
@@ -180,7 +181,7 @@ export default function Suppliers() {
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <Stack className="p-6" gap="1.5rem">
       {/* Header */}
       <div className="flex justify-between items-center">
         <div>
@@ -296,6 +297,6 @@ export default function Suppliers() {
         onClose={handleDetailsDialogClose}
         supplier={selectedSupplierForDetails}
       />
-    </div>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- add layout primitives: Container, Stack, AutoGrid, ResponsiveImage
- refactor pages to use new primitives

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden fetching date-fns)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e34d25c832d950adeea2bd5c6dc