### PR TITLE
refactor: let DB compute purchase total cost

### DIFF
--- a/src/components/boats/components/ComponentPurchaseDialog.tsx
+++ b/src/components/boats/components/ComponentPurchaseDialog.tsx
@@ -86,7 +86,6 @@ export function ComponentPurchaseDialog({ isOpen, onClose, componentId }: Compon
           purchase_date: data.purchaseDate?.toISOString().split('T')[0],
           unit_cost: data.unitCost,
           quantity: data.quantity,
-          total_cost: data.unitCost * data.quantity,
           warranty_months: data.warrantyMonths,
           invoice_reference: data.invoiceReference || null,
           installation_date: data.installationDate?.toISOString().split('T')[0] || null,


### PR DESCRIPTION
## Summary
- remove total_cost from component purchase history insert so database calculates it
- show total cost client-side using unit_cost * quantity only for display

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; attempted `npm install` but received 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68accac4f620832d9aeddf0e697a23cb