### PR TITLE
refactor: remove total cost from intervention inserts

### DIFF
--- a/src/components/maintenance/InterventionDialog.tsx
+++ b/src/components/maintenance/InterventionDialog.tsx
@@ -255,7 +255,6 @@ export function InterventionDialog({ isOpen, onClose, intervention }: Interventi
           part_name: part.partName,
           quantity: part.quantity,
           unit_cost: part.unitCost,
-          total_cost: part.totalCost,
           notes: part.notes || null
         }));
 


### PR DESCRIPTION
## Summary
- rely on DB-generated total cost for intervention parts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx supabase --help` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*

------
https://chatgpt.com/codex/tasks/task_e_68accc308760832da4fe1b86e96211cb