### PR TITLE
Avoid total_cost insert in stock scan workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "@capacitor-community/sqlite": "^7.0.1",

--- a/supabase/migrations/20250915120000_update_handle_stock_scan_workflow.sql
+++ b/supabase/migrations/20250915120000_update_handle_stock_scan_workflow.sql
@@ -1,0 +1,156 @@
+-- Ensure handle_stock_scan_workflow does not insert into total_cost (generated column)
+DROP TRIGGER IF EXISTS handle_stock_scan_workflow_trigger ON public.stock_items;
+DROP FUNCTION IF EXISTS public.handle_stock_scan_workflow();
+
+CREATE OR REPLACE FUNCTION public.handle_stock_scan_workflow()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  order_record RECORD;
+  order_item_record RECORD;
+  matched_count INTEGER := 0;
+BEGIN
+  -- Vérifier si c'est une augmentation de quantité (réception de stock)
+  IF NEW.quantity > OLD.quantity THEN
+    -- Chercher les commandes correspondantes en statut 'shipping_antilles'
+    FOR order_record IN
+      SELECT DISTINCT o.id, o.order_number, o.requested_by, o.supplier_id, o.base_id
+      FROM public.orders o
+      JOIN public.order_items oi ON oi.order_id = o.id
+      WHERE o.status = 'shipping_antilles'
+        AND o.base_id = NEW.base_id
+        AND (
+          -- Correspondance exacte par nom
+          LOWER(TRIM(oi.product_name)) = LOWER(TRIM(NEW.name))
+          -- Correspondance par référence si elle existe
+          OR (oi.reference IS NOT NULL AND NEW.reference IS NOT NULL
+              AND LOWER(TRIM(oi.reference)) = LOWER(TRIM(NEW.reference)))
+          -- Correspondance partielle pour les noms longs
+          OR (LENGTH(oi.product_name) > 5 AND LENGTH(NEW.name) > 5
+              AND (LOWER(oi.product_name) LIKE '%' || LOWER(NEW.name) || '%'
+                   OR LOWER(NEW.name) LIKE '%' || LOWER(oi.product_name) || '%'))
+        )
+    LOOP
+      -- Récupérer les détails de l'article commandé pour cette commande
+      SELECT * INTO order_item_record
+      FROM public.order_items oi
+      WHERE oi.order_id = order_record.id
+      AND (
+        LOWER(TRIM(oi.product_name)) = LOWER(TRIM(NEW.name))
+        OR (oi.reference IS NOT NULL AND NEW.reference IS NOT NULL
+            AND LOWER(TRIM(oi.reference)) = LOWER(TRIM(NEW.reference)))
+        OR (LENGTH(oi.product_name) > 5 AND LENGTH(NEW.name) > 5
+            AND (LOWER(oi.product_name) LIKE '%' || LOWER(NEW.name) || '%'
+                 OR LOWER(NEW.name) LIKE '%' || LOWER(oi.product_name) || '%'))
+      )
+      LIMIT 1;
+
+      -- Créer l'historique d'achat automatiquement (SANS total_cost - colonne générée)
+      IF order_item_record.id IS NOT NULL AND order_item_record.unit_price > 0 THEN
+        INSERT INTO public.component_purchase_history (
+          stock_item_id,
+          supplier_id,
+          order_id,
+          purchase_date,
+          unit_cost,
+          quantity,
+          warranty_months,
+          installation_date,
+          notes
+        ) VALUES (
+          NEW.id,
+          order_record.supplier_id,
+          order_record.id,
+          CURRENT_DATE,
+          order_item_record.unit_price,
+          (NEW.quantity - OLD.quantity), -- Quantité ajoutée
+          12, -- Garantie par défaut de 12 mois
+          CURRENT_DATE,
+          'Créé automatiquement lors du scan de réception - Commande: ' || order_record.order_number
+        );
+      END IF;
+
+      -- Faire avancer automatiquement le workflow vers 'received_scanned'
+      PERFORM public.advance_workflow_step(
+        order_record.id,
+        'received_scanned'::public.purchase_workflow_status,
+        auth.uid(), -- L'utilisateur qui a scanné
+        'Réception automatique via scan de stock - Article: ' || NEW.name || ' - Quantité ajoutée: ' || (NEW.quantity - OLD.quantity)
+      );
+
+      -- Puis directement vers 'completed'
+      PERFORM public.advance_workflow_step(
+        order_record.id,
+        'completed'::public.purchase_workflow_status,
+        auth.uid(),
+        'Demande d''achat terminée automatiquement suite au scan de réception'
+      );
+
+      -- Créer une notification de réception automatique
+      INSERT INTO public.workflow_notifications (
+        order_id, recipient_user_id, notification_type, title, message
+      ) VALUES (
+        order_record.id,
+        order_record.requested_by,
+        'auto_completion',
+        '✅ Demande d''achat terminée avec historique créé',
+        'Votre demande d''achat ' || order_record.order_number || ' a été automatiquement marquée comme terminée. L''historique d''achat a été créé avec le prix de ' || order_item_record.unit_price || '€.'
+      ) ON CONFLICT DO NOTHING;
+
+      -- Résoudre les alertes liées à cette commande
+      UPDATE public.workflow_alerts
+      SET is_resolved = true, resolved_at = now()
+      WHERE order_id = order_record.id AND is_resolved = false;
+
+      matched_count := matched_count + 1;
+
+      -- Log pour traçabilité
+      INSERT INTO public.security_events (
+        event_type,
+        user_id,
+        details
+      ) VALUES (
+        'stock_scan_purchase_history_created',
+        auth.uid(),
+        jsonb_build_object(
+          'stock_item_id', NEW.id,
+          'stock_item_name', NEW.name,
+          'order_id', order_record.id,
+          'order_number', order_record.order_number,
+          'unit_price', order_item_record.unit_price,
+          'quantity_added', NEW.quantity - OLD.quantity,
+          'purchase_history_created', true,
+          'timestamp', now()
+        )
+      );
+
+    END LOOP;
+
+    -- Si des demandes ont été mises à jour, créer une alerte avec le bon type
+    IF matched_count > 0 THEN
+      INSERT INTO public.alerts (
+        type,
+        severity,
+        title,
+        message,
+        base_id
+      ) VALUES (
+        'system',
+        'info',
+        'Historiques d''achat créés automatiquement',
+        matched_count || ' demande(s) d''achat ont été automatiquement terminées avec création d''historique d''achat pour "' || NEW.name || '".',
+        NEW.base_id
+      );
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+CREATE TRIGGER handle_stock_scan_workflow_trigger
+  AFTER UPDATE ON public.stock_items
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_stock_scan_workflow();

--- a/supabase/tests/handle_stock_scan_workflow.test.js
+++ b/supabase/tests/handle_stock_scan_workflow.test.js
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Ensure that the latest handle_stock_scan_workflow migration does not insert into total_cost
+// which is a generated column in component_purchase_history
+
+test('component_purchase_history inserts omit total_cost', () => {
+  const filePath = path.join('supabase', 'migrations', '20250915120000_update_handle_stock_scan_workflow.sql');
+  const sql = fs.readFileSync(filePath, 'utf-8');
+  const inserts = [...sql.matchAll(/INSERT INTO\s+public\.component_purchase_history\s*\(([^)]+)\)/gi)];
+  assert.ok(inserts.length > 0, 'No insert into component_purchase_history found');
+  for (const match of inserts) {
+    const columns = match[1].toLowerCase();
+    assert.ok(!columns.includes('total_cost'), 'total_cost column should be omitted from inserts');
+  }
+});


### PR DESCRIPTION
## Summary
- Recreate `handle_stock_scan_workflow` trigger without inserting into `total_cost`
- Add regression test checking the trigger migration omits `total_cost` in purchase history inserts
- Wire up test script

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68accc31c180832da5fc8d566fcff430