### PR TITLE
feat: store component purchase total cost

### DIFF
--- a/src/components/boats/components/ComponentPurchaseDialog.tsx
+++ b/src/components/boats/components/ComponentPurchaseDialog.tsx
@@ -86,6 +86,7 @@ export function ComponentPurchaseDialog({ isOpen, onClose, componentId }: Compon
           purchase_date: data.purchaseDate?.toISOString().split('T')[0],
           unit_cost: data.unitCost,
           quantity: data.quantity,
+          total_cost: data.unitCost * data.quantity,
           warranty_months: data.warrantyMonths,
           invoice_reference: data.invoiceReference || null,
           installation_date: data.installationDate?.toISOString().split('T')[0] || null,


### PR DESCRIPTION
## Summary
- store total purchase cost when saving component purchases

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68accf601f50832d953d8244ce7b9ebc