### PR TITLE
Handle missing total cost in purchase history

### DIFF
--- a/src/components/boats/ComponentPurchaseHistory.tsx
+++ b/src/components/boats/ComponentPurchaseHistory.tsx
@@ -77,7 +77,10 @@ export function ComponentPurchaseHistory({ componentId, subComponentId, componen
     );
   }
 
-  const totalCost = purchaseHistory.reduce((sum, item) => sum + item.total_cost, 0);
+  const totalCost = purchaseHistory.reduce(
+    (sum, item) => sum + (item.total_cost ?? item.quantity * item.unit_cost),
+    0
+  );
 
   return (
     <Card>
@@ -140,7 +143,9 @@ export function ComponentPurchaseHistory({ componentId, subComponentId, componen
                       
                       <div className="flex items-center gap-2 font-medium">
                         <DollarSign className="h-4 w-4" />
-                        <span>Total: {purchase.total_cost.toFixed(2)} €</span>
+                        <span>
+                          Total: {(purchase.total_cost ?? purchase.quantity * purchase.unit_cost).toFixed(2)} €
+                        </span>
                       </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- Add fallback when computing total cost for purchase items
- Use same fallback when summing total purchase history cost

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68accf613618832d9dff91d93621b0b5