### PR TITLE
chore: update offline table references

### DIFF
--- a/src/components/mobile/MobileDataManager.tsx
+++ b/src/components/mobile/MobileDataManager.tsx
@@ -68,7 +68,7 @@ export const MobileDataManager = () => {
       const db = await sqliteService.getDatabase();
       
       // Clear all offline tables
-      const tables = ['offline_stock', 'offline_suppliers', 'offline_boat_components', 'offline_maintenance_tasks'];
+      const tables = ['offline_stock_items', 'offline_suppliers', 'offline_boat_components', 'offline_maintenance_tasks'];
       
       for (const table of tables) {
         await db.execute(`DELETE FROM ${table}`);

--- a/src/hooks/useMobileSystem.ts
+++ b/src/hooks/useMobileSystem.ts
@@ -179,9 +179,9 @@ export const useMobileSystem = () => {
       
       // Clear all offline tables
       const tables = [
-        'offline_stock', 
-        'offline_suppliers', 
-        'offline_boat_components', 
+        'offline_stock_items',
+        'offline_suppliers',
+        'offline_boat_components',
         'offline_maintenance_tasks',
         'pending_changes',
         'sync_conflicts'
@@ -300,7 +300,7 @@ export const useMobileSystem = () => {
       const db = await sqliteService.getDatabase();
       
       // Count total records
-      const tables = ['offline_stock', 'offline_suppliers', 'offline_boat_components', 'offline_maintenance_tasks'];
+      const tables = ['offline_stock_items', 'offline_suppliers', 'offline_boat_components', 'offline_maintenance_tasks'];
       let totalRecords = 0;
       
       for (const table of tables) {


### PR DESCRIPTION
## Summary
- align offline data cleanup with new `offline_*` tables
- update database stats tracking to use new table names

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ae1d0a0458832da33cc4351474065d