### PR TITLE
Fix SQLite sync table list formatting

### DIFF
--- a/src/lib/database/sqlite.ts
+++ b/src/lib/database/sqlite.ts
@@ -262,7 +262,17 @@ class SQLiteService {
     }
 
     // Initialize sync metadata
-    const syncTables = ['boats', 'interventions', 'stock_items', 'orders', 'order_items', 'bases', 'suppliers', 'boat_components', 'maintenance_tasks'];
+    const syncTables = [
+      'boats',
+      'interventions',
+      'stock_items',
+      'orders',
+      'order_items',
+      'bases',
+      'suppliers',
+      'boat_components',
+      'maintenance_tasks'
+    ];
     for (const tableName of syncTables) {
       await this.db.run(
         `INSERT OR IGNORE INTO sync_metadata (table_name) VALUES (?)`,


### PR DESCRIPTION
## Summary
- format sync table list across multiple lines in SQLite service

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js' and npm install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae215e4e94832d8b604a712f137ea1