### PR TITLE
feat: sync additional tables by default

### DIFF
--- a/src/lib/offlineSync.ts
+++ b/src/lib/offlineSync.ts
@@ -9,7 +9,17 @@ export interface SyncOptions {
 
 export class OfflineSyncManager {
   private readonly defaultOptions: SyncOptions = {
-    tables: ['boats', 'interventions', 'stock_items', 'orders', 'suppliers', 'boat_components'],
+    tables: [
+      'bases',
+      'boats',
+      'interventions',
+      'stock_items',
+      'orders',
+      'order_items',
+      'suppliers',
+      'boat_components',
+      'maintenance_tasks'
+    ],
     conflictResolution: 'manual',
     batchSize: 50
   };


### PR DESCRIPTION
## Summary
- include bases, order_items, and maintenance_tasks in offline sync defaults

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ae2160106c832d8b443ec65ae06357