### PR TITLE
Limit base_id filtering to supported tables

### DIFF
--- a/src/lib/offlineSync.ts
+++ b/src/lib/offlineSync.ts
@@ -23,8 +23,16 @@ export class OfflineSyncManager {
       
       // Build query
       let query = (supabase as any).from(tableName).select('*');
-      
-      if (baseId) {
+
+      const baseFilteredTables = [
+        'boats',
+        'interventions',
+        'stock_items',
+        'orders',
+        'suppliers',
+        'boat_components'
+      ];
+      if (baseId && baseFilteredTables.includes(tableName)) {
         query = query.eq('base_id', baseId);
       }
       


### PR DESCRIPTION
## Summary
- only add `base_id` filter in offline sync for tables that include that column

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ae2162dcac832d976a2f9a55d3f9a5