### PR TITLE
Preserve purchase request flag across workflow statuses

### DIFF
--- a/src/components/orders/OrderDialog.tsx
+++ b/src/components/orders/OrderDialog.tsx
@@ -31,6 +31,7 @@ import { Button } from '@/components/ui/button';
 import { Order, Supplier, Base } from '@/types';
 import { ProductAutocomplete } from './ProductAutocomplete';
 import { CreateStockItemDialog } from './CreateStockItemDialog';
+import { isWorkflowStatus } from '@/lib/workflowUtils';
 
 interface OrderDialogProps {
   isOpen: boolean;
@@ -161,10 +162,11 @@ export function OrderDialog({ isOpen, onClose, order }: OrderDialogProps) {
 
   const onSubmit = async (data: OrderFormData) => {
     setIsSubmitting(true);
-    
+
     try {
       const totalAmount = calculateTotal(data.items);
-      
+      const isPurchaseRequest = order?.isPurchaseRequest || isWorkflowStatus(data.status);
+
       const orderData = {
         order_number: data.orderNumber,
         supplier_id: data.supplierId || null,
@@ -173,7 +175,7 @@ export function OrderDialog({ isOpen, onClose, order }: OrderDialogProps) {
         order_date: data.orderDate,
         delivery_date: data.deliveryDate || null,
         total_amount: totalAmount,
-        is_purchase_request: data.status === 'pending_approval',
+        is_purchase_request: isPurchaseRequest,
         requested_by: user?.id || null
       };
 

--- a/src/components/orders/PurchaseRequestDialog.tsx
+++ b/src/components/orders/PurchaseRequestDialog.tsx
@@ -15,6 +15,7 @@ import { ProductAutocomplete } from './ProductAutocomplete';
 import { PhotoUpload } from './PhotoUpload';
 import { Order, OrderItem } from '@/types';
 import { useToast } from '@/hooks/use-toast';
+import { isWorkflowStatus } from '@/lib/workflowUtils';
 
 interface PurchaseRequestDialogProps {
   isOpen: boolean;
@@ -251,7 +252,7 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (items.length === 0) {
       toast({
         title: "Erreur",
@@ -261,6 +262,7 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
       return;
     }
 
+    const isPurchaseRequest = order?.isPurchaseRequest || isWorkflowStatus(order?.status || 'pending_approval');
 
     const submitData = {
       boat_id: formData.boatId === 'none' ? null : formData.boatId,
@@ -269,7 +271,7 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
       tracking_url: formData.trackingUrl || null,
       photos: formData.photos,
       order_number: isEditing ? order?.orderNumber : `REQ-${Date.now().toString().slice(-6)}`,
-      is_purchase_request: true,
+      is_purchase_request: isPurchaseRequest,
       status: isEditing ? order?.status : 'pending_approval',
       requested_by: user?.id,
       base_id: user?.baseId,


### PR DESCRIPTION
## Summary
- derive purchase request flag from prior state or workflow statuses in order dialog
- retain purchase request flag when submitting purchase request dialog

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ae21d6af38832d9068b58652cd2ae5