### PR TITLE
feat: centralize workflow statuses

### DIFF
--- a/src/components/orders/OrderDialog.tsx
+++ b/src/components/orders/OrderDialog.tsx
@@ -29,6 +29,8 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Order, Supplier, Base } from '@/types';
+import { PURCHASE_WORKFLOW_STATUSES, LEGACY_WORKFLOW_STATUSES } from '@/types/workflow';
+import { getStatusLabel } from '@/lib/workflowUtils';
 import { ProductAutocomplete } from './ProductAutocomplete';
 import { CreateStockItemDialog } from './CreateStockItemDialog';
 
@@ -311,21 +313,16 @@ export function OrderDialog({ isOpen, onClose, order }: OrderDialogProps) {
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>
-                          {/* Workflow moderne */}
-                          <SelectItem value="draft">Brouillon</SelectItem>
-                          <SelectItem value="pending_approval">Demande d'achat (nécessite approbation)</SelectItem>
-                          <SelectItem value="approved">Approuvé (direction)</SelectItem>
-                          <SelectItem value="supplier_search">Recherche fournisseur</SelectItem>
-                          <SelectItem value="order_confirmed">Commande confirmée</SelectItem>
-                          <SelectItem value="shipping_antilles">Envoi vers Antilles</SelectItem>
-                          <SelectItem value="received_scanned">Réception scannée</SelectItem>
-                          <SelectItem value="completed">Terminé</SelectItem>
-                          {/* Statuts legacy */}
-                          <SelectItem value="pending">Ancienne - En attente</SelectItem>
-                          <SelectItem value="confirmed">Ancienne - Confirmée</SelectItem>
-                          <SelectItem value="delivered">Ancienne - Livrée</SelectItem>
-                          <SelectItem value="cancelled">Annulée</SelectItem>
-                          <SelectItem value="rejected">Rejetée</SelectItem>
+                          {PURCHASE_WORKFLOW_STATUSES.map((status) => (
+                            <SelectItem key={status} value={status}>
+                              {getStatusLabel(status)}
+                            </SelectItem>
+                          ))}
+                          {LEGACY_WORKFLOW_STATUSES.map((status) => (
+                            <SelectItem key={status} value={status}>
+                              {getStatusLabel(status)}
+                            </SelectItem>
+                          ))}
                         </SelectContent>
                       </Select>
                       <FormMessage />

--- a/src/components/orders/PurchaseRequestDialog.tsx
+++ b/src/components/orders/PurchaseRequestDialog.tsx
@@ -8,7 +8,9 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
-import { Plus, X, Upload, ExternalLink, Clock, CheckCircle, XCircle, Truck, Ship } from 'lucide-react';
+import { Plus, X, Upload, ExternalLink } from 'lucide-react';
+import * as Icons from 'lucide-react';
+import { getStatusLabel, getStatusColor, getStatusIcon } from '@/lib/workflowUtils';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { ProductAutocomplete } from './ProductAutocomplete';
@@ -36,23 +38,6 @@ const urgencyColors = {
   urgent: 'bg-red-100 text-red-800'
 };
 
-const statusLabels = {
-  pending_approval: 'En attente d\'approbation',
-  supplier_requested: 'Demande effectuée auprès du fournisseur',
-  shipping_mainland: 'Commande en cours de livraison - Métropole',
-  shipping_antilles: 'Commande en cours d\'envoi - Antilles',
-  delivered: 'Livrée',
-  cancelled: 'Annulée'
-};
-
-const statusIcons = {
-  pending_approval: Clock,
-  supplier_requested: CheckCircle,
-  shipping_mainland: Truck,
-  shipping_antilles: Ship,
-  delivered: CheckCircle,
-  cancelled: XCircle
-};
 
 export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseRequestDialogProps) {
   const { user } = useAuth();
@@ -282,7 +267,7 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
     mutation.mutate(submitData);
   };
 
-  const StatusIcon = order ? statusIcons[order.status as keyof typeof statusIcons] : null;
+  const StatusIcon = order ? Icons[getStatusIcon(order.status) as keyof typeof Icons] : null;
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -295,10 +280,10 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
               </DialogTitle>
               {order && (
                 <div className="flex items-center gap-2 mt-2">
-                  {StatusIcon && <StatusIcon className="h-4 w-4" />}
-                  <span className="text-sm text-muted-foreground">
-                    {statusLabels[order.status as keyof typeof statusLabels]}
-                  </span>
+                  {StatusIcon && <StatusIcon className="h-4 w-4 text-muted-foreground" />}
+                  <Badge className={getStatusColor(order.status)}>
+                    {getStatusLabel(order.status)}
+                  </Badge>
                 </div>
               )}
             </div>
@@ -466,7 +451,7 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
           </div>
 
           {/* Tracking URL - Only for direction and certain statuses */}
-          {user?.role === 'direction' && order && ['shipping_mainland', 'shipping_antilles'].includes(order.status) && (
+          {user?.role === 'direction' && order && order.status === 'ordered' && (
             <div>
               <Label htmlFor="tracking">URL de suivi transporteur</Label>
               <div className="flex gap-2">

--- a/src/components/orders/WorkflowActions.tsx
+++ b/src/components/orders/WorkflowActions.tsx
@@ -10,8 +10,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
 import { Order } from '@/types';
 import { WorkflowStatus } from '@/types/workflow';
-type PurchaseWorkflowStatus = 'draft' | 'pending_approval' | 'approved' | 'supplier_search' | 'ordered' | 'received' | 'completed' | 'rejected' | 'cancelled';
-import { CheckCircle, CheckCircle2, XCircle, Search, ShoppingCart, Ship, Settings } from 'lucide-react';
+import { CheckCircle, CheckCircle2, XCircle, Search, ShoppingCart, Settings } from 'lucide-react';
 import { SupplierPriceForm } from './SupplierPriceForm';
 import { ShippingTrackingForm } from './ShippingTrackingForm';
 interface WorkflowActionsProps {
@@ -38,7 +37,7 @@ export function WorkflowActions({
       newStatus,
       notes: notesParam
     }: {
-      newStatus: PurchaseWorkflowStatus;
+      newStatus: WorkflowStatus;
       notes?: string;
     }) => {
       const { error } = await supabase
@@ -94,14 +93,14 @@ export function WorkflowActions({
         label: 'Soumettre pour approbation',
         variant: 'default' as const,
         icon: CheckCircle,
-        newStatus: 'pending_approval' as PurchaseWorkflowStatus,
+        newStatus: 'pending_approval' as WorkflowStatus,
         requiresNotes: false
       }, {
         key: 'start_supplier_search',
         label: 'Commande directe (recherche fournisseur)',
         variant: 'outline' as const,
         icon: Search,
-        newStatus: 'supplier_search' as PurchaseWorkflowStatus,
+        newStatus: 'supplier_search' as WorkflowStatus,
         requiresNotes: false
       });
     }
@@ -114,14 +113,14 @@ export function WorkflowActions({
           label: 'Approuver',
           variant: 'default' as const,
           icon: CheckCircle,
-          newStatus: 'approved' as PurchaseWorkflowStatus,
+          newStatus: 'approved' as WorkflowStatus,
           requiresNotes: false
         }, {
           key: 'reject',
           label: 'Rejeter',
           variant: 'destructive' as const,
           icon: XCircle,
-          newStatus: 'rejected' as PurchaseWorkflowStatus,
+          newStatus: 'rejected' as WorkflowStatus,
           requiresNotes: true,
           useRejectionReason: true
         });
@@ -132,7 +131,7 @@ export function WorkflowActions({
           label: 'Recherche fournisseurs',
           variant: 'default' as const,
           icon: Search,
-          newStatus: 'supplier_search' as PurchaseWorkflowStatus,
+          newStatus: 'supplier_search' as WorkflowStatus,
           requiresNotes: false
         });
       }
@@ -154,7 +153,7 @@ export function WorkflowActions({
           label: 'Confirmer la commande',
           variant: 'default' as const,
           icon: ShoppingCart,
-          newStatus: 'ordered' as PurchaseWorkflowStatus,
+          newStatus: 'ordered' as WorkflowStatus,
           requiresNotes: false
         });
       }
@@ -164,7 +163,7 @@ export function WorkflowActions({
           label: 'Marquer comme reçu',
           variant: 'default' as const,
           icon: CheckCircle,
-          newStatus: 'received' as PurchaseWorkflowStatus,
+          newStatus: 'received' as WorkflowStatus,
           requiresNotes: false
         });
       }
@@ -174,7 +173,7 @@ export function WorkflowActions({
           label: 'Terminer la commande',
           variant: 'default' as const,
           icon: CheckCircle2,
-          newStatus: 'completed' as PurchaseWorkflowStatus,
+          newStatus: 'completed' as WorkflowStatus,
           requiresNotes: false
         });
       }
@@ -188,7 +187,7 @@ export function WorkflowActions({
           label: 'Recherche fournisseurs',
           variant: 'default' as const,
           icon: Search,
-          newStatus: 'supplier_search' as PurchaseWorkflowStatus,
+          newStatus: 'supplier_search' as WorkflowStatus,
           requiresNotes: false
         });
       }
@@ -198,7 +197,7 @@ export function WorkflowActions({
           label: 'Confirmer la commande',
           variant: 'default' as const,
           icon: ShoppingCart,
-          newStatus: 'ordered' as PurchaseWorkflowStatus,
+          newStatus: 'ordered' as WorkflowStatus,
           requiresNotes: false
         });
       }
@@ -211,7 +210,7 @@ export function WorkflowActions({
         label: 'Annuler',
         variant: 'outline' as const,
         icon: XCircle,
-        newStatus: 'cancelled' as PurchaseWorkflowStatus,
+        newStatus: 'cancelled' as WorkflowStatus,
         requiresNotes: true
       });
     }

--- a/src/lib/workflowUtils.ts
+++ b/src/lib/workflowUtils.ts
@@ -3,68 +3,18 @@ import { WorkflowStatus, WORKFLOW_STEPS } from '@/types/workflow';
 // Utilitaires centralisés pour la gestion du workflow
 
 export const getStatusColor = (status: string): string => {
-  // Correspondance directe pour les couleurs de statut
-  const statusColors: Record<string, string> = {
-    // Statuts simplifiés pour les commandes
-    'pending': 'bg-yellow-100 text-yellow-800',
-    'shipping': 'bg-blue-100 text-blue-800',
-    'delivered': 'bg-green-100 text-green-800',
-    // Statuts workflow pour les demandes d'achat
-    'pending_approval': 'bg-yellow-100 text-yellow-800',
-    'approved': 'bg-green-100 text-green-800',
-    'supplier_search': 'bg-blue-100 text-blue-800',
-    'ordered': 'bg-purple-100 text-purple-800',
-    'received': 'bg-teal-100 text-teal-800',
-    'completed': 'bg-green-100 text-green-800',
-    'rejected': 'bg-red-100 text-red-800',
-    'cancelled': 'bg-gray-100 text-gray-800',
-    // Legacy
-    'confirmed': 'bg-blue-100 text-blue-800',
-    'draft': 'bg-gray-100 text-gray-800'
-  };
-  
-  return statusColors[status] || 'bg-gray-100 text-gray-800';
+  const workflowStatus = status as WorkflowStatus;
+  return WORKFLOW_STEPS[workflowStatus]?.color || 'bg-gray-100 text-gray-800';
 };
 
 export const getStatusLabel = (status: string): string => {
-  // Correspondance directe pour les statuts utilisés
-  const statusLabels: Record<string, string> = {
-    // Statuts simplifiés pour les commandes
-    'pending': 'En cours',
-    'shipping': 'En cours de livraison', 
-    'delivered': 'Livrée',
-    // Statuts workflow pour les demandes d'achat
-    'pending_approval': 'En attente d\'approbation',
-    'approved': 'Approuvé',
-    'supplier_search': 'Recherche fournisseurs',
-    'ordered': 'Commande passée',
-    'received': 'Réception confirmée',
-    'completed': 'Terminé',
-    'rejected': 'Rejeté',
-    'cancelled': 'Annulé',
-    // Legacy
-    'confirmed': 'Confirmée',
-    'draft': 'Brouillon'
-  };
-  
-  return statusLabels[status] || status;
+  const workflowStatus = status as WorkflowStatus;
+  return WORKFLOW_STEPS[workflowStatus]?.label || status;
 };
 
 export const getStatusIcon = (status: string): string => {
   const workflowStatus = status as WorkflowStatus;
-  if (WORKFLOW_STEPS[workflowStatus]) {
-    return WORKFLOW_STEPS[workflowStatus].icon;
-  }
-  
-  // Fallback pour les anciens statuts
-  const legacyIcons: Record<string, string> = {
-    pending: 'Clock',
-    confirmed: 'CheckCircle',
-    delivered: 'Package',
-    cancelled: 'X'
-  };
-  
-  return legacyIcons[status] || 'Circle';
+  return WORKFLOW_STEPS[workflowStatus]?.icon || 'Circle';
 };
 
 export const isWorkflowStatus = (status: string): status is WorkflowStatus => {
@@ -74,19 +24,7 @@ export const isWorkflowStatus = (status: string): status is WorkflowStatus => {
 export const getWorkflowStatusList = () => {
   return [
     { value: 'all', label: 'Tous les statuts' },
-    // Statuts simplifiés pour les commandes
-    { value: 'pending', label: 'En cours' },
-    { value: 'shipping', label: 'En cours de livraison' },
-    { value: 'delivered', label: 'Livrée' },
-    // Statuts workflow pour les demandes d'achat
-    { value: 'pending_approval', label: 'En attente d\'approbation' },
-    { value: 'approved', label: 'Approuvé' },
-    { value: 'supplier_search', label: 'Recherche fournisseurs' },
-    { value: 'ordered', label: 'Commande passée' },
-    { value: 'received', label: 'Réception confirmée' },
-    { value: 'completed', label: 'Terminé' },
-    { value: 'rejected', label: 'Rejeté' },
-    { value: 'cancelled', label: 'Annulé' }
+    ...Object.entries(WORKFLOW_STEPS).map(([value, { label }]) => ({ value, label }))
   ];
 };
 
@@ -106,16 +44,16 @@ export const getNextPossibleActions = (currentStatus: WorkflowStatus, userRole: 
     confirmed: ['delivered', 'cancelled'],
     delivered: []
   };
-  
+
   return actions[currentStatus] || [];
 };
 
 export const canUserModifyStatus = (currentStatus: WorkflowStatus, userRole: string, baseId?: string, orderBaseId?: string): boolean => {
   if (userRole === 'direction') return true;
-  
+
   if (userRole === 'chef_base' && baseId === orderBaseId) {
     return !['pending_approval', 'rejected', 'completed'].includes(currentStatus);
   }
-  
+
   return false;
 };

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -1,6 +1,6 @@
-export type WorkflowStatus = 
+export type WorkflowStatus =
   | 'draft'
-  | 'pending_approval' 
+  | 'pending_approval'
   | 'approved'
   | 'supplier_search'
   | 'ordered'
@@ -12,6 +12,24 @@ export type WorkflowStatus =
   | 'pending'
   | 'confirmed'
   | 'delivered';
+
+export const PURCHASE_WORKFLOW_STATUSES: WorkflowStatus[] = [
+  'draft',
+  'pending_approval',
+  'approved',
+  'supplier_search',
+  'ordered',
+  'received',
+  'completed',
+  'rejected',
+  'cancelled'
+];
+
+export const LEGACY_WORKFLOW_STATUSES: WorkflowStatus[] = [
+  'pending',
+  'confirmed',
+  'delivered'
+];
 
 export interface WorkflowStep {
   id: string;


### PR DESCRIPTION
## Summary
- define shared workflow status lists and step metadata
- unify status helpers to reference central step definitions
- use official statuses in order dialogs and workflow actions

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ae21d571f8832d931c87f24d1be562