### PR TITLE
refactor: simplify workflow status handling

### DIFF
--- a/src/components/orders/OrderDialog.tsx
+++ b/src/components/orders/OrderDialog.tsx
@@ -29,8 +29,8 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Order, Supplier, Base } from '@/types';
-import { PURCHASE_WORKFLOW_STATUSES, LEGACY_WORKFLOW_STATUSES } from '@/types/workflow';
-import { getStatusLabel } from '@/lib/workflowUtils';
+import { LEGACY_WORKFLOW_STATUSES } from '@/types/workflow';
+import { getWorkflowStatusList } from '@/lib/workflowUtils';
 import { ProductAutocomplete } from './ProductAutocomplete';
 import { CreateStockItemDialog } from './CreateStockItemDialog';
 import { isWorkflowStatus } from '@/lib/workflowUtils';
@@ -126,6 +126,11 @@ export function OrderDialog({ isOpen, onClose, order }: OrderDialogProps) {
     },
     enabled: isOpen
   });
+
+  const includeLegacyStatuses = order ? LEGACY_WORKFLOW_STATUSES.includes(order.status) : false;
+  const workflowStatuses = getWorkflowStatusList(includeLegacyStatuses).filter(
+    (status) => status.value !== 'all'
+  );
 
   useEffect(() => {
     if (order) {
@@ -315,14 +320,9 @@ export function OrderDialog({ isOpen, onClose, order }: OrderDialogProps) {
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>
-                          {PURCHASE_WORKFLOW_STATUSES.map((status) => (
-                            <SelectItem key={status} value={status}>
-                              {getStatusLabel(status)}
-                            </SelectItem>
-                          ))}
-                          {LEGACY_WORKFLOW_STATUSES.map((status) => (
-                            <SelectItem key={status} value={status}>
-                              {getStatusLabel(status)}
+                          {workflowStatuses.map((status) => (
+                            <SelectItem key={status.value} value={status.value}>
+                              {status.label}
                             </SelectItem>
                           ))}
                         </SelectContent>

--- a/src/components/orders/PurchaseRequestDialog.tsx
+++ b/src/components/orders/PurchaseRequestDialog.tsx
@@ -17,7 +17,11 @@ import { ProductAutocomplete } from './ProductAutocomplete';
 import { PhotoUpload } from './PhotoUpload';
 import { Order, OrderItem } from '@/types';
 import { useToast } from '@/hooks/use-toast';
-import { isWorkflowStatus } from '@/lib/workflowUtils';
+import {
+  WorkflowStatus,
+  PURCHASE_WORKFLOW_STATUSES,
+  LEGACY_WORKFLOW_STATUSES,
+} from '@/types/workflow';
 
 interface PurchaseRequestDialogProps {
   isOpen: boolean;
@@ -94,6 +98,7 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
 
   const isEditing = !!order;
   const canEdit = user?.role === 'direction' || user?.role === 'chef_base' || (order && order.requestedBy === user?.id && order.status === 'pending_approval');
+  const includeLegacyStatus = order ? LEGACY_WORKFLOW_STATUSES.includes(order.status) : false;
 
   // Fetch boats for selection
   const { data: boats = [] } = useQuery({
@@ -247,7 +252,12 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
       return;
     }
 
-    const isPurchaseRequest = order?.isPurchaseRequest || isWorkflowStatus(order?.status || 'pending_approval');
+    const isPurchaseRequest =
+      order?.isPurchaseRequest ||
+      PURCHASE_WORKFLOW_STATUSES.includes(
+        ((order?.status || 'pending_approval') as WorkflowStatus)
+      ) ||
+      includeLegacyStatus;
 
     const submitData = {
       boat_id: formData.boatId === 'none' ? null : formData.boatId,

--- a/src/lib/workflowUtils.ts
+++ b/src/lib/workflowUtils.ts
@@ -1,4 +1,9 @@
-import { WorkflowStatus, WORKFLOW_STEPS } from '@/types/workflow';
+import {
+  WorkflowStatus,
+  WORKFLOW_STEPS,
+  PURCHASE_WORKFLOW_STATUSES,
+  LEGACY_WORKFLOW_STATUSES,
+} from '@/types/workflow';
 
 // Utilitaires centralisés pour la gestion du workflow
 
@@ -21,10 +26,13 @@ export const isWorkflowStatus = (status: string): status is WorkflowStatus => {
   return status in WORKFLOW_STEPS;
 };
 
-export const getWorkflowStatusList = () => {
+export const getWorkflowStatusList = (includeLegacy = false) => {
+  const statuses = includeLegacy
+    ? [...PURCHASE_WORKFLOW_STATUSES, ...LEGACY_WORKFLOW_STATUSES]
+    : PURCHASE_WORKFLOW_STATUSES;
   return [
     { value: 'all', label: 'Tous les statuts' },
-    ...Object.entries(WORKFLOW_STEPS).map(([value, { label }]) => ({ value, label }))
+    ...statuses.map((value) => ({ value, label: WORKFLOW_STEPS[value].label })),
   ];
 };
 


### PR DESCRIPTION
## Summary
- use purchase workflow statuses by default in order dialogs
- add optional legacy status inclusion for editing legacy orders
- restrict workflow status list to purchase statuses with optional legacy

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68af730703a4832d85275c91f21ee58a