### PR TITLE
refactor: limit workflow status detection to purchase

### DIFF
--- a/src/components/orders/OrderDialog.tsx
+++ b/src/components/orders/OrderDialog.tsx
@@ -30,10 +30,9 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Order, Supplier, Base } from '@/types';
 import { PURCHASE_WORKFLOW_STATUSES, LEGACY_WORKFLOW_STATUSES } from '@/types/workflow';
-import { getStatusLabel } from '@/lib/workflowUtils';
+import { getStatusLabel, isWorkflowStatus } from '@/lib/workflowUtils';
 import { ProductAutocomplete } from './ProductAutocomplete';
 import { CreateStockItemDialog } from './CreateStockItemDialog';
-import { isWorkflowStatus } from '@/lib/workflowUtils';
 
 interface OrderDialogProps {
   isOpen: boolean;

--- a/src/components/orders/PurchaseRequestDialog.tsx
+++ b/src/components/orders/PurchaseRequestDialog.tsx
@@ -10,14 +10,13 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Plus, X, Upload, ExternalLink } from 'lucide-react';
 import * as Icons from 'lucide-react';
-import { getStatusLabel, getStatusColor, getStatusIcon } from '@/lib/workflowUtils';
+import { getStatusLabel, getStatusColor, getStatusIcon, isWorkflowStatus } from '@/lib/workflowUtils';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { ProductAutocomplete } from './ProductAutocomplete';
 import { PhotoUpload } from './PhotoUpload';
 import { Order, OrderItem } from '@/types';
 import { useToast } from '@/hooks/use-toast';
-import { isWorkflowStatus } from '@/lib/workflowUtils';
 
 interface PurchaseRequestDialogProps {
   isOpen: boolean;

--- a/src/lib/workflowUtils.ts
+++ b/src/lib/workflowUtils.ts
@@ -1,4 +1,4 @@
-import { WorkflowStatus, WORKFLOW_STEPS } from '@/types/workflow';
+import { WorkflowStatus, WORKFLOW_STEPS, PURCHASE_WORKFLOW_STATUSES } from '@/types/workflow';
 
 // Utilitaires centralisés pour la gestion du workflow
 
@@ -17,9 +17,8 @@ export const getStatusIcon = (status: string): string => {
   return WORKFLOW_STEPS[workflowStatus]?.icon || 'Circle';
 };
 
-export const isWorkflowStatus = (status: string): status is WorkflowStatus => {
-  return status in WORKFLOW_STEPS;
-};
+export const isWorkflowStatus = (status: string): status is WorkflowStatus =>
+  PURCHASE_WORKFLOW_STATUSES.includes(status as WorkflowStatus);
 
 export const getWorkflowStatusList = () => {
   return [


### PR DESCRIPTION
## Summary
- narrow `isWorkflowStatus` to PURCHASE_WORKFLOW_STATUSES only
- ensure dialogs set `is_purchase_request` only for new workflow statuses

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68af7307fa24832d9944ee400cf30cb4