### PR TITLE
Use workflow status to trigger workflow UI

### DIFF
--- a/src/components/orders/OrderDialog.tsx
+++ b/src/components/orders/OrderDialog.tsx
@@ -167,7 +167,9 @@ export function OrderDialog({ isOpen, onClose, order }: OrderDialogProps) {
 
     try {
       const totalAmount = calculateTotal(data.items);
-      const isPurchaseRequest = order?.isPurchaseRequest || isWorkflowStatus(data.status);
+      const isPurchaseRequest = order && isWorkflowStatus(order.status)
+        ? order.isPurchaseRequest
+        : isWorkflowStatus(data.status);
 
       const orderData = {
         order_number: data.orderNumber,

--- a/src/components/orders/OrderTableEnhanced.tsx
+++ b/src/components/orders/OrderTableEnhanced.tsx
@@ -21,7 +21,7 @@ import { Order } from '@/types';
 import { formatCurrency } from '@/lib/utils';
 import { WorkflowActions } from '@/components/orders/WorkflowActions';
 import { WorkflowStatusIndicator } from '@/components/orders/WorkflowStatusIndicator';
-import { getStatusColor, getStatusLabel } from '@/lib/workflowUtils';
+import { getStatusColor, getStatusLabel, isWorkflowStatus } from '@/lib/workflowUtils';
 import { AddToStockButton } from '@/components/orders/AddToStockButton';
 import { WorkflowStatus } from '@/types/workflow';
 import { useAuth } from '@/contexts/AuthContext';
@@ -116,9 +116,9 @@ export function OrderTableEnhanced({
               </TableCell>
               
               <TableCell>
-                {order.isPurchaseRequest ? (
-                  <WorkflowStatusIndicator 
-                    status={order.status as WorkflowStatus} 
+                {isWorkflowStatus(order.status) ? (
+                  <WorkflowStatusIndicator
+                    status={order.status as WorkflowStatus}
                     showIcon={true}
                     showProgress={!showCompactView}
                     size={showCompactView ? 'sm' : 'md'}
@@ -160,10 +160,10 @@ export function OrderTableEnhanced({
                 </TableCell>
               )}
               
-              {user?.role === 'direction' && order.isPurchaseRequest && (
+              {user?.role === 'direction' && isWorkflowStatus(order.status) && (
                 <TableCell>
-                  <WorkflowActions 
-                    order={order} 
+                  <WorkflowActions
+                    order={order}
                     onOrderUpdate={onOrderUpdate}
                   />
                 </TableCell>

--- a/src/components/orders/WorkflowActions.tsx
+++ b/src/components/orders/WorkflowActions.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
 import { Order } from '@/types';
 import { WorkflowStatus } from '@/types/workflow';
+import { isWorkflowStatus } from '@/lib/workflowUtils';
 import { CheckCircle, CheckCircle2, XCircle, Search, ShoppingCart, Settings } from 'lucide-react';
 import { SupplierPriceForm } from './SupplierPriceForm';
 import { ShippingTrackingForm } from './ShippingTrackingForm';
@@ -79,9 +80,8 @@ export function WorkflowActions({
     const actions = [];
     if (!user) return actions;
 
-    // Skip workflow actions for legacy statuses that don't support new workflow
-    const legacyStatuses = ['pending', 'confirmed', 'delivered'];
-    if (legacyStatuses.includes(order.status)) {
+    // Skip workflow actions for orders not using the new workflow
+    if (!isWorkflowStatus(order.status)) {
       return actions;
     }
 


### PR DESCRIPTION
## Summary
- Show workflow indicator and actions when order status is part of workflow
- Skip workflow actions for orders outside the workflow
- Preserve existing `is_purchase_request` flag when updating workflow orders

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68af7309edb8832db2ecd916c0f2bcad