### PR TITLE
feat: centralize workflow transitions

### DIFF
--- a/src/lib/workflowUtils.ts
+++ b/src/lib/workflowUtils.ts
@@ -1,4 +1,4 @@
-import { WorkflowStatus, WORKFLOW_STEPS } from '@/types/workflow';
+import { WorkflowStatus, WORKFLOW_STEPS, getNextPossibleActions } from '@/types/workflow';
 
 // Utilitaires centralisés pour la gestion du workflow
 
@@ -28,25 +28,8 @@ export const getWorkflowStatusList = () => {
   ];
 };
 
-export const getNextPossibleActions = (currentStatus: WorkflowStatus, userRole: string): WorkflowStatus[] => {
-  const actions: Record<WorkflowStatus, WorkflowStatus[]> = {
-    draft: ['pending_approval'],
-    pending_approval: userRole === 'direction' ? ['approved', 'rejected'] : [],
-    approved: ['supplier_search'],
-    supplier_search: ['ordered'],
-    ordered: ['received'],
-    received: ['completed'],
-    completed: [],
-    rejected: [],
-    cancelled: [],
-    // Legacy statuses - limited actions
-    pending: ['confirmed', 'cancelled'],
-    confirmed: ['delivered', 'cancelled'],
-    delivered: []
-  };
 
-  return actions[currentStatus] || [];
-};
+export { getNextPossibleActions };
 
 export const canUserModifyStatus = (currentStatus: WorkflowStatus, userRole: string, baseId?: string, orderBaseId?: string): boolean => {
   if (userRole === 'direction') return true;


### PR DESCRIPTION
## Summary
- centralize workflow action definitions in workflow types
- expose transition helper for reuse
- consume centralized actions in order workflow buttons

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68af730c17f0832d84d2df7c78200e39