### PR TITLE
refactor: remove order number from purchase request form

### DIFF
--- a/src/components/orders/PurchaseRequestDialog.tsx
+++ b/src/components/orders/PurchaseRequestDialog.tsx
@@ -50,7 +50,6 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
   const queryClient = useQueryClient();
   
   const [formData, setFormData] = useState({
-    orderNumber: order?.orderNumber || '',
     boatId: order?.boatId || 'none',
     urgencyLevel: (order?.urgencyLevel || 'normal') as 'low' | 'normal' | 'high' | 'urgent',
     requestNotes: order?.requestNotes || '',


### PR DESCRIPTION
## Summary
- drop orderNumber from PurchaseRequestDialog form state
- submit purchase request using order.orderNumber or generated value

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68af76c24324832d9ed012bc312abdd2