### PR TITLE
fix: reset order dialog when closing

### DIFF
--- a/src/components/orders/OrderDialog.tsx
+++ b/src/components/orders/OrderDialog.tsx
@@ -239,7 +239,7 @@ export function OrderDialog({ isOpen, onClose, order }: OrderDialogProps) {
           : "La nouvelle commande a été créée avec succès."
       });
 
-      onClose();
+      handleClose();
     } catch (error) {
       console.error('Error saving order:', error);
       toast({


### PR DESCRIPTION
## Summary
- ensure order dialog resets before closing by calling `handleClose`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af76c37a3c832da51f08bea85a972f