### PR TITLE
Default order status respects purchase request flag

### DIFF
--- a/src/components/orders/OrderDialog.tsx
+++ b/src/components/orders/OrderDialog.tsx
@@ -63,12 +63,14 @@ export function OrderDialog({ isOpen, onClose, order }: OrderDialogProps) {
   const [createStockDialogOpen, setCreateStockDialogOpen] = useState(false);
   const [newProductName, setNewProductName] = useState('');
 
+  const defaultIsPurchaseRequest = order?.isPurchaseRequest ?? false;
+
   const form = useForm<OrderFormData>({
     defaultValues: {
       orderNumber: '',
       supplierId: '',
       baseId: '',
-        status: 'draft',
+      status: defaultIsPurchaseRequest ? 'draft' : 'pending',
       orderDate: new Date().toISOString().split('T')[0],
       deliveryDate: '',
       items: [{ productName: '', reference: '', quantity: 1, unitPrice: 0 }]
@@ -155,13 +157,13 @@ export function OrderDialog({ isOpen, onClose, order }: OrderDialogProps) {
         orderNumber,
         supplierId: '',
         baseId: user?.role === 'direction' ? '' : (user?.baseId || ''),
-        status: 'draft',
+        status: defaultIsPurchaseRequest ? 'draft' : 'pending',
         orderDate: new Date().toISOString().split('T')[0],
         deliveryDate: '',
         items: [{ productName: '', reference: '', quantity: 1, unitPrice: 0 }]
       });
     }
-  }, [order, form, user]);
+  }, [order, form, user, defaultIsPurchaseRequest]);
 
   const calculateTotal = (items: any[]) => {
     return items.reduce((total, item) => total + (item.quantity * item.unitPrice), 0);


### PR DESCRIPTION
## Summary
- Use purchase request flag to choose draft or pending as default order status
- Reset new orders with status based on default purchase request mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af76c49c68832dbf4c72791fe61edf