### PR TITLE
Always mark orders as purchase requests

### DIFF
--- a/src/components/orders/PurchaseRequestDialog.tsx
+++ b/src/components/orders/PurchaseRequestDialog.tsx
@@ -17,11 +17,6 @@ import { ProductAutocomplete } from './ProductAutocomplete';
 import { PhotoUpload } from './PhotoUpload';
 import { Order, OrderItem } from '@/types';
 import { useToast } from '@/hooks/use-toast';
-import {
-  WorkflowStatus,
-  PURCHASE_WORKFLOW_STATUSES,
-  LEGACY_WORKFLOW_STATUSES,
-} from '@/types/workflow';
 
 interface PurchaseRequestDialogProps {
   isOpen: boolean;
@@ -97,8 +92,10 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
   }, [isOpen, order?.id]);
 
   const isEditing = !!order;
-  const canEdit = user?.role === 'direction' || user?.role === 'chef_base' || (order && order.requestedBy === user?.id && order.status === 'pending_approval');
-  const includeLegacyStatus = order ? LEGACY_WORKFLOW_STATUSES.includes(order.status) : false;
+  const canEdit =
+    user?.role === 'direction' ||
+    user?.role === 'chef_base' ||
+    (order && order.requestedBy === user?.id && order.status === 'pending_approval');
 
   // Fetch boats for selection
   const { data: boats = [] } = useQuery({
@@ -252,13 +249,6 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
       return;
     }
 
-    const isPurchaseRequest =
-      order?.isPurchaseRequest ||
-      PURCHASE_WORKFLOW_STATUSES.includes(
-        ((order?.status || 'pending_approval') as WorkflowStatus)
-      ) ||
-      includeLegacyStatus;
-
     const submitData = {
       boat_id: formData.boatId === 'none' ? null : formData.boatId,
       urgency_level: formData.urgencyLevel,
@@ -266,15 +256,13 @@ export function PurchaseRequestDialog({ isOpen, onClose, order }: PurchaseReques
       tracking_url: formData.trackingUrl || null,
       photos: formData.photos,
       order_number: isEditing ? order?.orderNumber : `REQ-${Date.now().toString().slice(-6)}`,
-      is_purchase_request: isPurchaseRequest,
+      is_purchase_request: true,
       status: isEditing ? order?.status : 'pending_approval',
       requested_by: user?.id,
       base_id: user?.baseId,
       order_date: new Date().toISOString().split('T')[0],
       total_amount: items.reduce((sum, item) => sum + (item.quantity * item.unitPrice), 0)
     };
-
-    
 
     mutation.mutate(submitData);
   };


### PR DESCRIPTION
## Summary
- Simplify purchase request dialog to always set `is_purchase_request` to `true`
- Remove unused workflow status logic

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js; npm install failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af76c67588832daf1c26995b18b1da