### PR TITLE
feat: enhance supply request stock search and photo capture

### DIFF
--- a/src/components/supply/PhotoCapture.tsx
+++ b/src/components/supply/PhotoCapture.tsx
@@ -1,0 +1,155 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Camera, X } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { supabase } from '@/integrations/supabase/client';
+
+interface PhotoCaptureProps {
+  photoUrl: string | null;
+  onPhotoChange: (url: string | null) => void;
+}
+
+export function PhotoCapture({ photoUrl, onPhotoChange }: PhotoCaptureProps) {
+  const { toast } = useToast();
+  const [showCamera, setShowCamera] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  useEffect(() => {
+    return () => {
+      closeCamera();
+    };
+  }, []);
+
+  const startCamera = async () => {
+    try {
+      setShowCamera(true);
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'environment', width: { ideal: 1920 }, height: { ideal: 1080 } }
+      });
+      streamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+      }
+    } catch (error) {
+      console.error('Error accessing camera:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Erreur',
+        description: "Impossible d'accéder à la caméra. Vérifiez les permissions.",
+      });
+      setShowCamera(false);
+    }
+  };
+
+  const uploadPhoto = async (file: File): Promise<void> => {
+    try {
+      setIsUploading(true);
+      const fileExt = file.name.split('.').pop();
+      const fileName = `${Math.random().toString(36).substring(2)}.${fileExt}`;
+      const filePath = `supply-requests/${fileName}`;
+      const { error: uploadError } = await supabase.storage
+        .from('stock-photos')
+        .upload(filePath, file);
+      if (uploadError) throw uploadError;
+      const { data } = supabase.storage
+        .from('stock-photos')
+        .getPublicUrl(filePath);
+      onPhotoChange(data.publicUrl);
+      toast({
+        title: 'Photo ajoutée',
+        description: 'La photo a été téléchargée avec succès.',
+      });
+    } catch (error) {
+      console.error('Error uploading photo:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Erreur',
+        description: "Erreur lors du téléchargement de la photo",
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const capturePhoto = () => {
+    if (videoRef.current && canvasRef.current) {
+      const video = videoRef.current;
+      const canvas = canvasRef.current;
+      const context = canvas.getContext('2d');
+      if (context) {
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        context.drawImage(video, 0, 0);
+        canvas.toBlob((blob) => {
+          if (blob) {
+            const file = new File([blob], 'camera-photo.jpg', { type: 'image/jpeg' });
+            uploadPhoto(file);
+            closeCamera();
+          }
+        }, 'image/jpeg', 0.8);
+      }
+    }
+  };
+
+  const closeCamera = () => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach(track => track.stop());
+      streamRef.current = null;
+    }
+    setShowCamera(false);
+  };
+
+  const removePhoto = () => {
+    onPhotoChange(null);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Button type="button" variant="outline" onClick={startCamera} disabled={isUploading}>
+        <Camera className="h-4 w-4 mr-2" />
+        Prendre une photo
+      </Button>
+      {photoUrl && (
+        <div className="relative w-32 h-32">
+          <img src={photoUrl} alt="Preview" className="w-full h-full object-cover rounded border" />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="absolute top-1 right-1"
+            onClick={removePhoto}
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </div>
+      )}
+
+      <Dialog open={showCamera} onOpenChange={(open) => !open && closeCamera()}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Prendre une photo</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <video ref={videoRef} autoPlay playsInline className="w-full h-64 object-cover rounded-lg bg-gray-800" />
+            <div className="flex justify-center gap-2">
+              <Button onClick={capturePhoto} disabled={isUploading} className="flex-1">
+                <Camera className="h-4 w-4 mr-2" />
+                Capturer
+              </Button>
+              <Button onClick={closeCamera} variant="outline">
+                Annuler
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <canvas ref={canvasRef} className="hidden" />
+    </div>
+  );
+}
+

--- a/src/components/supply/SupplyRequestDialog.tsx
+++ b/src/components/supply/SupplyRequestDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useAuth } from '@/contexts/AuthContext';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -10,10 +10,11 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { Camera, Plus, Search, X } from 'lucide-react';
+import { Plus, X } from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
 import { StockItemAutocomplete } from '@/components/stock/StockItemAutocomplete';
-import { CreateStockItemDialog } from '@/components/orders/CreateStockItemDialog';
+import { PhotoCapture } from './PhotoCapture';
+import { useNavigate } from 'react-router-dom';
 
 interface FormData {
   boat_id: string;
@@ -33,11 +34,10 @@ interface SupplyRequestDialogProps {
 
 export function SupplyRequestDialog({ isOpen, onClose, onSuccess }: SupplyRequestDialogProps) {
   const { user } = useAuth();
-  const queryClient = useQueryClient();
   const [selectedStockItem, setSelectedStockItem] = useState<any>(null);
-  const [isCreateStockDialogOpen, setIsCreateStockDialogOpen] = useState(false);
-  const [photoFile, setPhotoFile] = useState<File | null>(null);
-  const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+  const [searchValue, setSearchValue] = useState('');
+  const [photoUrl, setPhotoUrl] = useState<string | null>(null);
+  const navigate = useNavigate();
 
   const form = useForm<FormData>({
     defaultValues: {
@@ -56,7 +56,27 @@ export function SupplyRequestDialog({ isOpen, onClose, onSuccess }: SupplyReques
     queryKey: ['boats-for-supply'],
     queryFn: async () => {
       let query = supabase.from('boats').select('id, name').order('name');
-      
+
+      if (user?.role !== 'direction') {
+        query = query.eq('base_id', user?.baseId);
+      }
+
+      const { data, error } = await query;
+      if (error) throw error;
+      return data;
+    },
+    enabled: isOpen,
+  });
+
+  // Fetch stock items for autocomplete
+  const { data: stockItems = [] } = useQuery({
+    queryKey: ['stock-items-for-supply', user?.baseId],
+    queryFn: async () => {
+      let query = supabase
+        .from('stock_items')
+        .select('id, name, reference, quantity, category, location')
+        .order('name');
+
       if (user?.role !== 'direction') {
         query = query.eq('base_id', user?.baseId);
       }
@@ -71,28 +91,6 @@ export function SupplyRequestDialog({ isOpen, onClose, onSuccess }: SupplyReques
   // Create supply request mutation
   const createMutation = useMutation({
     mutationFn: async (data: FormData) => {
-      let photoUrl = data.photo_url;
-
-      // Upload photo if selected
-      if (photoFile) {
-        const fileExt = photoFile.name.split('.').pop();
-        const fileName = `${Math.random().toString(36).substring(2)}.${fileExt}`;
-        const filePath = `supply-requests/${fileName}`;
-
-        const { error: uploadError } = await supabase.storage
-          .from('stock-photos')
-          .upload(filePath, photoFile);
-
-        if (uploadError) {
-          console.error('Error uploading photo:', uploadError);
-        } else {
-          const { data: { publicUrl } } = supabase.storage
-            .from('stock-photos')
-            .getPublicUrl(filePath);
-          photoUrl = publicUrl;
-        }
-      }
-
       const requestData = {
         item_name: data.item_name,
         item_reference: data.item_reference || null,
@@ -100,7 +98,7 @@ export function SupplyRequestDialog({ isOpen, onClose, onSuccess }: SupplyReques
         quantity_needed: data.quantity_needed,
         urgency_level: data.urgency_level,
         boat_id: data.boat_id === 'none' ? null : data.boat_id,
-        photo_url: photoUrl || null,
+        photo_url: data.photo_url || null,
         base_id: user?.baseId,
         requested_by: user?.id,
       };
@@ -122,8 +120,8 @@ export function SupplyRequestDialog({ isOpen, onClose, onSuccess }: SupplyReques
       onSuccess();
       form.reset();
       setSelectedStockItem(null);
-      setPhotoFile(null);
-      setPhotoPreview(null);
+      setPhotoUrl(null);
+      setSearchValue('');
     },
     onError: (error) => {
       console.error('Error creating supply request:', error);
@@ -144,27 +142,8 @@ export function SupplyRequestDialog({ isOpen, onClose, onSuccess }: SupplyReques
     }
   };
 
-  const handlePhotoCapture = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      setPhotoFile(file);
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        setPhotoPreview(e.target?.result as string);
-      };
-      reader.readAsDataURL(file);
-    }
-  };
-
   const handleCreateNewStock = () => {
-    setIsCreateStockDialogOpen(true);
-  };
-
-  const handleStockCreated = (newItem: any) => {
-    setSelectedStockItem(newItem);
-    form.setValue('item_name', newItem.name);
-    form.setValue('item_reference', newItem.reference || '');
-    setIsCreateStockDialogOpen(false);
+    navigate('/stock?create=1');
   };
 
   const onSubmit = (data: FormData) => {
@@ -175,8 +154,8 @@ export function SupplyRequestDialog({ isOpen, onClose, onSuccess }: SupplyReques
     if (!isOpen) {
       form.reset();
       setSelectedStockItem(null);
-      setPhotoFile(null);
-      setPhotoPreview(null);
+      setPhotoUrl(null);
+      setSearchValue('');
     }
   }, [isOpen, form]);
 
@@ -194,15 +173,12 @@ export function SupplyRequestDialog({ isOpen, onClose, onSuccess }: SupplyReques
               <Label>Rechercher un article existant</Label>
               <div className="flex gap-2">
                 <div className="flex-1">
-                  <Input
+                  <StockItemAutocomplete
+                    stockItems={stockItems}
+                    value={searchValue}
+                    onChange={setSearchValue}
+                    onSelect={handleStockItemSelect}
                     placeholder="Rechercher dans le stock..."
-                    onClick={() => {
-                      // For now, just show a message that this feature needs implementation
-                      toast({
-                        title: "Recherche de stock",
-                        description: "Cette fonctionnalité sera bientôt disponible.",
-                      });
-                    }}
                   />
                 </div>
                 <Button type="button" variant="outline" onClick={handleCreateNewStock}>
@@ -308,48 +284,16 @@ export function SupplyRequestDialog({ isOpen, onClose, onSuccess }: SupplyReques
               </Select>
             </div>
 
-            {/* Photo Upload */}
+            {/* Photo Capture */}
             <div className="space-y-2">
               <Label>Photo (optionnel)</Label>
-              <div className="flex gap-2">
-                <Input
-                  type="file"
-                  accept="image/*"
-                  capture="environment"
-                  onChange={handlePhotoCapture}
-                  className="hidden"
-                  id="photo-input"
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => document.getElementById('photo-input')?.click()}
-                >
-                  <Camera className="h-4 w-4 mr-2" />
-                  Prendre une photo
-                </Button>
-              </div>
-              {photoPreview && (
-                <div className="relative w-32 h-32">
-                  <img
-                    src={photoPreview}
-                    alt="Preview"
-                    className="w-full h-full object-cover rounded border"
-                  />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="absolute top-1 right-1"
-                    onClick={() => {
-                      setPhotoFile(null);
-                      setPhotoPreview(null);
-                    }}
-                  >
-                    <X className="h-3 w-3" />
-                  </Button>
-                </div>
-              )}
+              <PhotoCapture
+                photoUrl={photoUrl}
+                onPhotoChange={(url) => {
+                  setPhotoUrl(url);
+                  form.setValue('photo_url', url || '');
+                }}
+              />
             </div>
 
             <div className="flex gap-2 justify-end">
@@ -364,7 +308,6 @@ export function SupplyRequestDialog({ isOpen, onClose, onSuccess }: SupplyReques
         </DialogContent>
       </Dialog>
 
-      {/* CreateStockItemDialog would go here - simplified for now */}
     </>
   );
 }

--- a/src/pages/Stock.tsx
+++ b/src/pages/Stock.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useOfflineData } from '@/lib/hooks/useOfflineData';
 import { Plus, Search, AlertTriangle, FileSpreadsheet } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -18,6 +18,7 @@ import { useToast } from '@/hooks/use-toast';
 import { StockItem } from '@/types';
 import { MobileTable, ResponsiveBadge } from '@/components/ui/mobile-table';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export default function Stock() {
   const { user } = useAuth();
@@ -37,8 +38,19 @@ export default function Stock() {
   const [isDeleting, setIsDeleting] = useState(false);
   const { toast } = useToast();
   const isMobile = useIsMobile();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const baseId = user?.role !== 'direction' ? user?.baseId : undefined;
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.get('create') === '1') {
+      setEditingItem(null);
+      setIsDialogOpen(true);
+      navigate('/stock', { replace: true });
+    }
+  }, [location.search, navigate]);
 
   const {
     data: rawStockItems = [],


### PR DESCRIPTION
## Summary
- add stock item autocomplete and navigation to stock creation
- enable camera capture for supply request photos
- open stock creation dialog via query parameter

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b0b0bf7604832dbcffc12acabf1f5a