### PR TITLE
Restrict technicien access to preventive maintenance page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 
 import { Toaster as Sonner } from "@/components/ui/sonner";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
@@ -27,7 +26,7 @@ import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
 
-function ProtectedRoute({ children }: { children: React.ReactNode }) {
+function ProtectedRoute({ children, allowedRoles }: { children: React.ReactNode; allowedRoles?: Array<'direction' | 'chef_base' | 'technicien'> }) {
   const { isAuthenticated, loading, session, user } = useAuth();
   
   // Show loading spinner while auth is initializing
@@ -46,7 +45,11 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   if (!session || !user || !isAuthenticated) {
     return <Navigate to="/auth" replace />;
   }
-  
+
+  if (allowedRoles && !allowedRoles.includes(user.role)) {
+    return <Navigate to="/maintenance" replace />;
+  }
+
   return <>{children}</>;
 }
 
@@ -150,7 +153,7 @@ function AppRoutes() {
       <Route
         path="/maintenance/preventive"
         element={
-          <ProtectedRoute>
+          <ProtectedRoute allowedRoles={['direction', 'chef_base']}>
             <MaintenancePreventive />
           </ProtectedRoute>
         }

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { Sidebar, SidebarContent, SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarMenuSub, SidebarMenuSubItem, SidebarMenuSubButton, useSidebar } from '@/components/ui/sidebar';
-import { BarChart3, Ship, Users, Package, Wrench, ShoppingCart, Settings, Shield, ChevronDown } from 'lucide-react';
+import { BarChart3, Ship, Users, Package, Wrench, ShoppingCart, Settings, ChevronDown } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -63,7 +63,8 @@ const menuItems = [{
     },
     {
       title: 'Préventive',
-      url: '/maintenance/preventive'
+      url: '/maintenance/preventive',
+      roles: ['direction', 'chef_base']
     },
     {
       title: 'Planning',
@@ -112,7 +113,14 @@ export function AppSidebar() {
     };
     fetchBaseName();
   }, [user?.baseId, user?.role]);
-  const filteredMenuItems = menuItems.filter(item => user && item.roles.includes(user.role));
+  const filteredMenuItems = menuItems
+    .filter(item => user && item.roles.includes(user.role))
+    .map(item => ({
+      ...item,
+      subItems: item.subItems?.filter(subItem =>
+        !subItem.roles || (user && subItem.roles.includes(user.role))
+      )
+    }));
 
   const handleNavClick = () => {
     if (isMobile) {
@@ -129,7 +137,7 @@ export function AppSidebar() {
     setOpenSubMenus(prev => ({ ...prev, [title]: open }));
   };
 
-  const isSubItemActive = (subItems: Array<{url: string}>) => {
+  const isSubItemActive = (subItems: Array<{url: string; roles?: string[] }>) => {
     return subItems.some(subItem => location.pathname === subItem.url);
   };
   return (


### PR DESCRIPTION
## Summary
- hide Preventive maintenance menu entry from technicien role
- block direct route access to maintenance/preventive for techniciens

## Testing
- `npm test`
- `npm run lint` *(fails: eslint not found; npm install fails due to dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ae127ba4832d89d3438d18e036c4