### PR TITLE
fix: link stock scan to supply requests

### DIFF
--- a/src/components/stock/OrderLinkDialog.tsx
+++ b/src/components/stock/OrderLinkDialog.tsx
@@ -33,30 +33,35 @@ export function OrderLinkDialog({
   const { toast } = useToast();
   const [isLinking, setIsLinking] = useState(false);
 
-  // Récupérer les commandes en cours qui pourraient correspondre
-  const { data: potentialOrders, isLoading } = useQuery({
-    queryKey: ['potential-orders', stockItemName],
+  // Récupérer les demandes d'approvisionnement qui pourraient correspondre
+  const { data: potentialRequests, isLoading } = useQuery({
+    queryKey: ['potential-requests', stockItemId],
     queryFn: async () => {
+      // Récupérer la référence de l'article pour améliorer la correspondance
+      const { data: stockItem } = await supabase
+        .from('stock_items')
+        .select('reference')
+        .eq('id', stockItemId)
+        .single();
+
+      const itemReference = stockItem?.reference || '';
+
       const { data, error } = await supabase
-        .from('orders')
+        .from('supply_requests')
         .select(`
           id,
-          order_number,
+          request_number,
           status,
           created_at,
-          supplier:suppliers(name),
-          order_items!inner(
-            id,
-            product_name,
-            quantity,
-            reference
-          )
+          item_name,
+          item_reference,
+          quantity_needed,
+          supplier_name
         `)
         .eq('base_id', user?.baseId)
-        .in('status', ['ordered', 'supplier_search'])
+        .not('status', 'in', '("completed","rejected")')
         .or(
-          `product_name.ilike.%${stockItemName}%,reference.ilike.%${stockItemName}%`,
-          { foreignTable: 'order_items' }
+          `item_name.ilike.%${stockItemName}%,item_reference.ilike.%${itemReference}%`
         )
         .order('created_at', { ascending: false })
         .limit(5);
@@ -64,36 +69,33 @@ export function OrderLinkDialog({
       if (error) throw error;
       return data || [];
     },
-    enabled: isOpen && !!stockItemName,
+    enabled: isOpen && !!stockItemId,
   });
 
-  const handleLinkToOrder = async (orderId: string) => {
+  const handleLinkToRequest = async (request: any) => {
     setIsLinking(true);
     try {
-      const { data, error } = await supabase.rpc('link_stock_scan_to_order', {
-        stock_item_id_param: stockItemId,
-        order_id_param: orderId,
-        quantity_received_param: quantityReceived
-      });
+      const { error } = await supabase
+        .from('supply_requests')
+        .update({
+          status: 'completed',
+          stock_item_id: stockItemId,
+          completed_at: new Date().toISOString(),
+        })
+        .eq('id', request.id);
 
       if (error) throw error;
 
-      const result = data as { success: boolean; order_number?: string; error?: string };
-
-      if (result?.success) {
-        toast({
-          title: 'Liaison réussie',
-          description: `Stock lié à la commande ${result.order_number}`,
-        });
-        onClose();
-      } else {
-        throw new Error(result?.error || 'Erreur lors de la liaison');
-      }
+      toast({
+        title: 'Liaison réussie',
+        description: `Stock lié à la demande ${request.request_number}`,
+      });
+      onClose();
     } catch (error) {
       console.error('Erreur liaison commande:', error);
       toast({
         title: 'Erreur',
-        description: 'Impossible de lier le stock à cette commande',
+        description: 'Impossible de lier le stock à cette demande',
         variant: 'destructive'
       });
     } finally {
@@ -124,26 +126,22 @@ export function OrderLinkDialog({
 
           {isLoading ? (
             <div className="text-center py-4">Recherche des commandes...</div>
-          ) : potentialOrders && potentialOrders.length > 0 ? (
+          ) : potentialRequests && potentialRequests.length > 0 ? (
             <div className="space-y-3">
               <h3 className="font-medium">Commandes correspondantes possibles :</h3>
-              {potentialOrders.map((order: any) => (
-                <Card key={order.id} className="p-3">
+              {potentialRequests.map((request: any) => (
+                <Card key={request.id} className="p-3">
                   <CardContent className="p-0">
                     <div className="flex items-center justify-between mb-2">
                       <div>
-                        <span className="font-medium">{order.order_number}</span>
-                        <Badge 
-                          variant={order.status === 'ordered' ? 'default' : 'secondary'}
-                          className="ml-2"
-                        >
-                          {order.status === 'draft' ? 'Brouillon' : 
-                           order.status === 'ordered' ? 'Commandé' : order.status}
+                        <span className="font-medium">{request.request_number}</span>
+                        <Badge variant="secondary" className="ml-2">
+                          {request.status}
                         </Badge>
                       </div>
                       <Button
                         size="sm"
-                        onClick={() => handleLinkToOrder(order.id)}
+                        onClick={() => handleLinkToRequest(request)}
                         disabled={isLinking}
                         className="flex items-center gap-1"
                       >
@@ -151,23 +149,10 @@ export function OrderLinkDialog({
                         Lier
                       </Button>
                     </div>
-                    
-                    {order.supplier && (
-                      <p className="text-sm text-muted-foreground mb-2">
-                        Fournisseur: {order.supplier.name}
-                      </p>
-                    )}
-                    
-                    <div className="text-xs text-muted-foreground">
-                      Articles commandés:
-                      <ul className="ml-2 mt-1">
-                        {order.order_items.map((item: any) => (
-                          <li key={item.id}>
-                            • {item.product_name} (Qté: {item.quantity})
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
+
+                    <p className="text-sm text-muted-foreground mb-2">
+                      {request.item_name} (Qté: {request.quantity_needed})
+                    </p>
                   </CardContent>
                 </Card>
               ))}
@@ -186,7 +171,7 @@ export function OrderLinkDialog({
             <Button variant="outline" onClick={onClose}>
               Fermer
             </Button>
-            {potentialOrders && potentialOrders.length === 0 && (
+            {potentialRequests && potentialRequests.length === 0 && (
               <Button onClick={onClose} className="flex items-center gap-1">
                 <Check className="h-3 w-3" />
                 Continuer sans liaison


### PR DESCRIPTION
## Summary
- search open supply requests matching scanned items by name or reference
- mark selected supply request as completed and link it to the stock item

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b0b4ec2e4c832d9a4e044c5b2523c2