### PR TITLE
refactor: match orders to scanned stock items by ID

### DIFF
--- a/src/components/stock/OrderLinkDialog.tsx
+++ b/src/components/stock/OrderLinkDialog.tsx
@@ -55,7 +55,7 @@ export function OrderLinkDialog({
         `)
         .eq('base_id', user?.baseId)
         .in('status', ['ordered', 'supplier_search'])
-        .eq('stock_item_id', stockItemId, { foreignTable: 'order_items' })
+        .eq('order_items.stock_item_id', stockItemId)
         .order('created_at', { ascending: false })
         .limit(5);
 


### PR DESCRIPTION
## Summary
- simplify order lookup by filtering joined order items using stock item ID

## Testing
- `npm test`
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bb34c67c832d8fe4a9dcb0109c87