### PR TITLE
Link scanned items to supply requests

### DIFF
--- a/src/components/stock/OrderLinkDialog.tsx
+++ b/src/components/stock/OrderLinkDialog.tsx
@@ -63,30 +63,30 @@ export function OrderLinkDialog({
   const handleLinkToOrder = async (requestId: string) => {
     setIsLinking(true);
     try {
-      const { data, error } = await supabase.rpc('link_stock_scan_to_order', {
+      const { data, error } = await supabase.rpc('link_stock_scan_to_supply_request', {
         stock_item_id_param: stockItemId,
-        order_id_param: requestId,
+        request_id_param: requestId,
         quantity_received_param: quantityReceived
       });
 
       if (error) throw error;
 
-      const result = data as { success: boolean; order_number?: string; error?: string };
+      const result = data as { success: boolean; request_number?: string; error?: string };
 
       if (result?.success) {
         toast({
           title: 'Liaison réussie',
-          description: `Stock lié à la commande ${result.order_number}`,
+          description: `Stock lié à la demande ${result.request_number}`,
         });
         onClose();
       } else {
         throw new Error(result?.error || 'Erreur lors de la liaison');
       }
     } catch (error) {
-      console.error('Erreur liaison commande:', error);
+      console.error('Erreur liaison demande:', error);
       toast({
         title: 'Erreur',
-        description: 'Impossible de lier le stock à cette commande',
+        description: 'Impossible de lier le stock à cette demande',
         variant: 'destructive'
       });
     } finally {
@@ -100,7 +100,7 @@ export function OrderLinkDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Link className="h-5 w-5" />
-            Lier le scan à une commande
+            Lier le scan à une demande
           </DialogTitle>
         </DialogHeader>
 
@@ -116,7 +116,7 @@ export function OrderLinkDialog({
           </div>
 
           {isLoading ? (
-            <div className="text-center py-4">Recherche des commandes...</div>
+            <div className="text-center py-4">Recherche des demandes...</div>
           ) : potentialRequests && potentialRequests.length > 0 ? (
             <div className="space-y-3">
               <h3 className="font-medium">Demandes correspondantes possibles :</h3>
@@ -160,9 +160,9 @@ export function OrderLinkDialog({
           ) : (
             <div className="text-center py-6 text-muted-foreground">
               <Package className="h-12 w-12 mx-auto mb-2 opacity-50" />
-              <p>Aucune commande correspondante trouvée</p>
+              <p>Aucune demande correspondante trouvée</p>
               <p className="text-sm mt-1">
-                L'article a été ajouté au stock sans liaison à une commande
+                L'article a été ajouté au stock sans liaison à une demande
               </p>
             </div>
           )}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -3553,6 +3553,14 @@ export type Database = {
         }
         Returns: Json
       }
+      link_stock_scan_to_supply_request: {
+        Args: {
+          request_id_param: string
+          quantity_received_param: number
+          stock_item_id_param: string
+        }
+        Returns: Json
+      }
       process_workflow_automation: {
         Args: Record<PropertyKey, never>
         Returns: undefined

--- a/supabase/migrations/20250916120000_link_stock_scan_to_supply_request.sql
+++ b/supabase/migrations/20250916120000_link_stock_scan_to_supply_request.sql
@@ -1,0 +1,94 @@
+CREATE OR REPLACE FUNCTION public.link_stock_scan_to_supply_request(
+  stock_item_id_param uuid,
+  request_id_param uuid,
+  quantity_received_param integer
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  request_record RECORD;
+BEGIN
+  -- Fetch the supply request details
+  SELECT sr.*, s.id AS supplier_id
+  INTO request_record
+  FROM public.supply_requests sr
+  LEFT JOIN public.suppliers s ON s.name = sr.supplier_name
+  WHERE sr.id = request_id_param;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Demande non trouvée');
+  END IF;
+
+  -- Mark request as completed and link stock item
+  UPDATE public.supply_requests
+  SET
+    status = 'completed',
+    completed_at = now(),
+    stock_item_id = stock_item_id_param,
+    updated_at = now()
+  WHERE id = request_id_param;
+
+  -- Log purchase history (optional)
+  BEGIN
+    INSERT INTO public.component_purchase_history (
+      stock_item_id,
+      supplier_id,
+      purchase_date,
+      unit_cost,
+      quantity,
+      warranty_months,
+      notes
+    ) VALUES (
+      stock_item_id_param,
+      request_record.supplier_id,
+      CURRENT_DATE,
+      0,
+      quantity_received_param,
+      12,
+      'Lié manuellement via scan - Demande: ' || request_record.request_number
+    );
+  EXCEPTION
+    WHEN OTHERS THEN
+      -- Log the error but don't fail the operation
+      INSERT INTO public.security_events (
+        event_type,
+        user_id,
+        details
+      ) VALUES (
+        'manual_stock_link_error',
+        auth.uid(),
+        jsonb_build_object(
+          'error', SQLERRM,
+          'stock_item_id', stock_item_id_param,
+          'request_id', request_id_param
+        )
+      );
+  END;
+
+  -- Notify the requester
+  INSERT INTO public.notifications (
+    user_id,
+    type,
+    title,
+    message,
+    data
+  ) VALUES (
+    request_record.requested_by,
+    'supply_request_completed',
+    '✅ Demande d''approvisionnement terminée',
+    'Votre demande ' || request_record.request_number || ' a été clôturée suite à la réception en stock.',
+    jsonb_build_object(
+      'request_id', request_record.id,
+      'request_number', request_record.request_number,
+      'stock_item_id', stock_item_id_param
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'request_number', request_record.request_number
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary
- Allow linking a scanned stock item to a supply request
- Mark linked supply requests as completed via new RPC
- Update Supabase types for the new function

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b0c34283d8832daf3a94ca93451029