### PR TITLE
Refresh supply request after linking stock

### DIFF
--- a/src/components/stock/OrderLinkDialog.tsx
+++ b/src/components/stock/OrderLinkDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
@@ -32,6 +32,7 @@ export function OrderLinkDialog({
   const { user } = useAuth();
   const { toast } = useToast();
   const [isLinking, setIsLinking] = useState(false);
+  const queryClient = useQueryClient();
 
   // Récupérer les demandes d'approvisionnement correspondantes
   const { data: potentialRequests, isLoading } = useQuery({
@@ -74,6 +75,8 @@ export function OrderLinkDialog({
       const result = data as { success: boolean; request_number?: string; error?: string };
 
       if (result?.success) {
+        await queryClient.invalidateQueries({ queryKey: ['supply-requests'] });
+        await queryClient.invalidateQueries({ queryKey: ['stock'] });
         toast({
           title: 'Liaison réussie',
           description: `Stock lié à la demande ${result.request_number}`,


### PR DESCRIPTION
## Summary
- Invalidate supply request and stock queries after linking a scan to a supply request

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js'; `npm ci` failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b60bc8eef4832db1f6018674902ba9