### PR TITLE
Fix technician access to profile settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -240,7 +240,7 @@ function AppRoutes() {
       <Route
         path="/settings"
         element={
-          <ProtectedRoute>
+          <ProtectedRoute allowedRoles={['direction', 'chef_base', 'technicien']}>
             <Settings />
           </ProtectedRoute>
         }


### PR DESCRIPTION
## Summary
- Ensure technicians can open the settings page by explicitly allowing the role in the protected route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde81c051c832d9244732bfbf81f54