### PR TITLE
Add distribution page permission control

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,7 +131,7 @@ function AppRoutes() {
         path="/distribution"
         element={
           <ProtectedRoute>
-            <PermissionGate page="stock">
+            <PermissionGate page="distribution">
               <Distribution />
             </PermissionGate>
           </ProtectedRoute>

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -10,6 +10,7 @@ export type PagePermission =
   | 'orders'
   | 'stock'
   | 'stock_scanner'
+  | 'distribution'
   | 'maintenance'
   | 'maintenance_gantt'
   | 'maintenance_history'
@@ -25,6 +26,7 @@ export const PAGE_PERMISSIONS: Record<PagePermission, string> = {
   orders: 'Commandes',
   stock: 'Stock',
   stock_scanner: 'Scanner stock',
+  distribution: 'Distribution',
   maintenance: 'Maintenance',
   maintenance_gantt: 'Planning Gantt',
   maintenance_history: 'Historique maintenance',

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4147,6 +4147,7 @@ export type Database = {
         | "orders"
         | "stock"
         | "stock_scanner"
+        | "distribution"
         | "maintenance"
         | "maintenance_gantt"
         | "maintenance_history"
@@ -4343,6 +4344,7 @@ export const Constants = {
         "orders",
         "stock",
         "stock_scanner",
+        "distribution",
         "maintenance",
         "maintenance_gantt",
         "maintenance_history",

--- a/supabase/migrations/20250910120000_add_distribution_permission.sql
+++ b/supabase/migrations/20250910120000_add_distribution_permission.sql
@@ -1,0 +1,2 @@
+-- Add distribution page permission
+ALTER TYPE public.page_permission ADD VALUE IF NOT EXISTS 'distribution';


### PR DESCRIPTION
## Summary
- allow setting technician access for the distribution page
- gate distribution route behind new permission
- support distribution permission in Supabase types and migrations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde8432820832d83ef8c6f2d552c1a