### PR TITLE
feat: improve distribution package traceability

### DIFF
--- a/src/components/distribution/PackagesList.tsx
+++ b/src/components/distribution/PackagesList.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ItemsList } from '@/components/distribution/ItemsList';
+import { Package } from 'lucide-react';
+
+interface ShipmentPackage {
+  id: string;
+  package_code: string;
+}
+
+interface ShipmentItem {
+  id: string;
+  sku: string;
+  product_label: string;
+  qty: number;
+  package_id?: string;
+  received_qty?: number;
+}
+
+interface PackagesListProps {
+  packages: ShipmentPackage[];
+  items: ShipmentItem[];
+}
+
+export function PackagesList({ packages, items }: PackagesListProps) {
+  if (packages.length === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        <Package className="w-12 h-12 mx-auto mb-4 opacity-50" />
+        <p>Aucun colis créé pour l'expédition</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {packages.map((pkg) => (
+        <Card key={pkg.id}>
+          <CardHeader>
+            <CardTitle>Colis {pkg.package_code}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ItemsList
+              items={items.filter((it) => it.package_id === pkg.id)}
+              readOnly
+            />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/distribution/PreparationTab.tsx
+++ b/src/components/distribution/PreparationTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -11,9 +11,9 @@ import { toast } from '@/hooks/use-toast';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { ScanInput } from '@/components/distribution/ScanInput';
-import { ItemsList } from '@/components/distribution/ItemsList';
+import { PackagesList } from '@/components/distribution/PackagesList';
 import { useAuth } from '@/contexts/AuthContext';
-import { Package, Plus, Send, QrCode } from 'lucide-react';
+import { Package, Plus, Send } from 'lucide-react';
 
 interface ShipmentFormData {
   sourceBaseId: string;
@@ -42,6 +42,12 @@ interface Shipment {
   items?: ShipmentItem[];
 }
 
+interface BaseStockItem {
+  id: string;
+  reference: string;
+  quantity: number;
+}
+
 const CARRIERS = [
   'Chronopost',
   'Colissimo', 
@@ -64,7 +70,6 @@ export function PreparationTab() {
     notes: ''
   });
   const [packageCode, setPackageCode] = useState('');
-  const [showPackageInput, setShowPackageInput] = useState(false);
 
   // Fetch bases for selection
   const { data: bases = [] } = useQuery({
@@ -84,16 +89,48 @@ export function PreparationTab() {
     queryKey: ['shipment-items', currentShipment?.id],
     queryFn: async () => {
       if (!currentShipment?.id) return [];
-      
+
       const { data, error } = await supabase
         .from('shipment_items')
         .select('*')
         .eq('shipment_id', currentShipment.id);
-      
+
       if (error) throw error;
       return data;
     },
     enabled: !!currentShipment?.id
+  });
+
+  // Fetch shipment packages
+  const { data: packages = [], refetch: refetchPackages } = useQuery({
+    queryKey: ['shipment-packages', currentShipment?.id],
+    queryFn: async () => {
+      if (!currentShipment?.id) return [];
+
+      const { data, error } = await supabase
+        .from('shipment_packages')
+        .select('*')
+        .eq('shipment_id', currentShipment.id);
+
+      if (error) throw error;
+      return data;
+    },
+    enabled: !!currentShipment?.id
+  });
+
+  // Fetch stock items for source base
+  const { data: stockItems = [] } = useQuery({
+    queryKey: ['stock-items', formData.sourceBaseId],
+    queryFn: async () => {
+      if (!formData.sourceBaseId) return [];
+      const { data, error } = await supabase
+        .from('stock_items')
+        .select('id, reference, quantity')
+        .eq('base_id', formData.sourceBaseId);
+      if (error) throw error;
+      return data as BaseStockItem[];
+    },
+    enabled: !!formData.sourceBaseId
   });
 
   // Create shipment mutation
@@ -149,9 +186,10 @@ export function PreparationTab() {
     },
     onSuccess: () => {
       refetchItems();
+      refetchPackages();
       toast({
         title: 'Article ajouté',
-        description: 'L\'article a été ajouté à l\'expédition.'
+        description: 'L\'article a été ajouté au colis.'
       });
     },
     onError: (error) => {
@@ -177,8 +215,8 @@ export function PreparationTab() {
     onSuccess: () => {
       setCurrentShipment(prev => prev ? { ...prev, status: 'packed' } : null);
       toast({
-        title: 'Colis fermé',
-        description: 'Le colis est prêt pour l\'expédition.'
+        title: 'Préparation terminée',
+        description: 'Tous les colis sont prêts pour l\'expédition.'
       });
     }
   });
@@ -204,6 +242,7 @@ export function PreparationTab() {
         notes: ''
       });
       queryClient.invalidateQueries({ queryKey: ['shipments'] });
+      queryClient.invalidateQueries({ queryKey: ['stock-items'] });
       toast({
         title: 'Expédition envoyée',
         description: 'L\'expédition a été marquée comme envoyée. Les articles ont été sortis du stock.'
@@ -225,21 +264,32 @@ export function PreparationTab() {
   };
 
   const handleScan = (sku: string) => {
-    addItemMutation.mutate({ sku, qty: 1, packageCode: packageCode || undefined });
-  };
-
-  const handlePackageCodeSubmit = () => {
     if (!packageCode.trim()) {
       toast({
-        title: 'Erreur',
-        description: 'Veuillez saisir un code de colis.',
+        title: 'Colis non défini',
+        description: 'Veuillez saisir un code de colis avant de scanner.',
         variant: 'destructive'
       });
       return;
     }
-    
-    packShipmentMutation.mutate();
-    setShowPackageInput(false);
+    const stockItem = stockItems.find((item: BaseStockItem) => item.reference === sku);
+    if (!stockItem) {
+      toast({
+        title: 'Référence inconnue',
+        description: 'Cet article n\'existe pas dans le stock de la base source.',
+        variant: 'destructive'
+      });
+      return;
+    }
+    if (stockItem.quantity <= 0) {
+      toast({
+        title: 'Stock insuffisant',
+        description: `Stock disponible: ${stockItem.quantity}`,
+        variant: 'destructive'
+      });
+      return;
+    }
+    addItemMutation.mutate({ sku, qty: 1, packageCode });
   };
 
   const canShip = currentShipment?.status === 'packed' && 
@@ -373,45 +423,35 @@ export function PreparationTab() {
 
           {currentShipment.status === 'draft' && (
             <>
-              <ScanInput onScan={handleScan} disabled={addItemMutation.isPending} />
-              
-              <ItemsList 
-                items={shipmentItems}
-                onQuantityChange={(itemId, newQty) => {
-                  // TODO: Implement quantity update
-                }}
-                showPackageCode
-              />
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="packageCode">Code du colis en cours</Label>
+                  <Input
+                    id="packageCode"
+                    value={packageCode}
+                    onChange={(e) => setPackageCode(e.target.value)}
+                    placeholder="Ex: G27"
+                  />
+                </div>
+                <div>
+                  <ScanInput
+                    onScan={handleScan}
+                    disabled={addItemMutation.isPending || !packageCode.trim()}
+                  />
+                </div>
+              </div>
+
+              <PackagesList packages={packages} items={shipmentItems} />
 
               <Separator />
 
-              <div className="flex flex-col sm:flex-row gap-4">
-                {!showPackageInput ? (
-                  <Button
-                    onClick={() => setShowPackageInput(true)}
-                    disabled={shipmentItems.length === 0}
-                    variant="outline"
-                  >
-                    <QrCode className="w-4 h-4 mr-2" />
-                    Fermer le colis
-                  </Button>
-                ) : (
-                  <div className="flex gap-2 flex-1">
-                    <Input
-                      value={packageCode}
-                      onChange={(e) => setPackageCode(e.target.value)}
-                      placeholder="Code du colis (ex: G27)"
-                      className="flex-1"
-                    />
-                    <Button onClick={handlePackageCodeSubmit} disabled={packShipmentMutation.isPending}>
-                      Valider
-                    </Button>
-                    <Button variant="outline" onClick={() => setShowPackageInput(false)}>
-                      Annuler
-                    </Button>
-                  </div>
-                )}
-              </div>
+              <Button
+                onClick={() => packShipmentMutation.mutate()}
+                disabled={packShipmentMutation.isPending || shipmentItems.length === 0}
+                className="w-full sm:w-auto"
+              >
+                Terminer la préparation
+              </Button>
             </>
           )}
 
@@ -419,10 +459,10 @@ export function PreparationTab() {
             <div className="space-y-4">
               <div className="bg-green-50 dark:bg-green-950 p-4 rounded-lg">
                 <p className="text-green-800 dark:text-green-200 font-medium">
-                  ✅ Colis fermé et prêt pour l'expédition
+                  ✅ Préparation terminée
                 </p>
                 <p className="text-green-600 dark:text-green-400 text-sm mt-1">
-                  {shipmentItems.length} article(s) dans ce colis
+                  {packages.length} colis - {shipmentItems.length} article(s)
                 </p>
               </div>
 

--- a/src/components/distribution/ReceptionTab.tsx
+++ b/src/components/distribution/ReceptionTab.tsx
@@ -89,6 +89,7 @@ export function ReceptionTab() {
     },
     onSuccess: () => {
       refetchShipments();
+      queryClient.invalidateQueries({ queryKey: ['stock-items'] });
       toast({
         title: 'Article reçu',
         description: 'L\'article a été ajouté au stock de destination.'

--- a/src/components/distribution/TrackingTab.tsx
+++ b/src/components/distribution/TrackingTab.tsx
@@ -6,8 +6,8 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Separator } from '@/components/ui/separator';
-import { Search, Package, Truck, ExternalLink, Download, QrCode } from 'lucide-react';
+import { Search, Package, Truck, ExternalLink, Download } from 'lucide-react';
+import { ItemsList } from '@/components/distribution/ItemsList';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 
@@ -150,10 +150,6 @@ export function TrackingTab() {
     }
   };
 
-  const generateQRCode = (shipmentId: string, packageCode: string) => {
-    return `${shipmentId}|${packageCode}`;
-  };
-
   const handlePrintLabel = (shipmentId: string, packageCode: string) => {
     // TODO: Implement PDF generation
     console.log('Impression étiquette:', { shipmentId, packageCode });
@@ -227,66 +223,27 @@ export function TrackingTab() {
         {shipmentDetails?.packages && shipmentDetails.packages.length > 0 && (
           <Card>
             <CardHeader>
-              <CardTitle>Colis et étiquettes</CardTitle>
+              <CardTitle>Colis expédiés</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <div className="space-y-4">
                 {shipmentDetails.packages.map((pkg) => (
-                  <div key={pkg.id} className="border rounded-lg p-4 space-y-3">
+                  <div key={pkg.id} className="border rounded-lg p-4 space-y-4">
                     <div className="flex items-center justify-between">
                       <h4 className="font-semibold">Colis {pkg.package_code}</h4>
-                      <QrCode className="w-5 h-5 text-muted-foreground" />
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handlePrintLabel(selectedShipment.id, pkg.package_code)}
+                      >
+                        <Download className="w-4 h-4 mr-2" />
+                        Étiquette
+                      </Button>
                     </div>
-                    
-                    <div className="text-sm">
-                      <p className="text-muted-foreground">QR Code Data:</p>
-                      <p className="font-mono text-xs break-all">
-                        {generateQRCode(selectedShipment.id, pkg.package_code)}
-                      </p>
-                    </div>
-
-                    <div className="text-sm">
-                      <p className="text-muted-foreground">Articles:</p>
-                      <p className="font-medium">
-                        {shipmentDetails.items?.filter(item => item.package_id === pkg.id).length || 0} article(s)
-                      </p>
-                    </div>
-
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handlePrintLabel(selectedShipment.id, pkg.package_code)}
-                      className="w-full"
-                    >
-                      <Download className="w-4 h-4 mr-2" />
-                      Imprimer étiquette
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
-        {shipmentDetails?.items && shipmentDetails.items.length > 0 && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Articles expédiés</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-2">
-                {shipmentDetails.items.map((item) => (
-                  <div key={item.id} className="flex justify-between items-center p-3 border rounded">
-                    <div>
-                      <p className="font-medium">{item.product_label || item.sku}</p>
-                      <p className="text-sm text-muted-foreground">SKU: {item.sku}</p>
-                    </div>
-                    <div className="text-right">
-                      <p className="font-medium">Qté: {item.qty}</p>
-                      {item.received_qty !== undefined && (
-                        <p className="text-sm text-muted-foreground">Reçu: {item.received_qty}</p>
-                      )}
-                    </div>
+                    <ItemsList
+                      items={shipmentDetails.items?.filter(item => item.package_id === pkg.id) || []}
+                      readOnly
+                    />
                   </div>
                 ))}
               </div>

--- a/src/pages/Distribution.tsx
+++ b/src/pages/Distribution.tsx
@@ -24,7 +24,7 @@ export default function Distribution() {
         <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="preparation" className="flex items-center gap-1 sm:gap-2">
             <Package className="h-4 w-4" />
-            <span className="hidden sm:inline">Préparer & scanner</span>
+            <span className="hidden sm:inline">Préparer</span>
             <span className="sm:hidden">Préparer</span>
           </TabsTrigger>
           <TabsTrigger value="tracking" className="flex items-center gap-1 sm:gap-2">
@@ -44,10 +44,10 @@ export default function Distribution() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Package className="h-5 w-5" />
-                Préparation et scan des expéditions
+                Préparation des expéditions
               </CardTitle>
               <CardDescription>
-                Créez un envoi, scannez les articles et préparez les colis pour l'expédition
+                Créez un envoi, scannez les articles et organisez-les dans des colis
               </CardDescription>
             </CardHeader>
             <CardContent>


### PR DESCRIPTION
## Summary
- streamline distribution preparation UI and remove redundant scan label
- support multiple packages with per-package item lists
- show package contents in tracking view
- validate scans against current stock and refresh stock data on shipment or reception

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde91f1d1c832db2d1cd212ccc2616