### PR TITLE
feat: improve tablet responsiveness

### DIFF
--- a/docs/RESPONSIVE_GUIDE.md
+++ b/docs/RESPONSIVE_GUIDE.md
@@ -1,0 +1,24 @@
+# Responsive Utilities Guide
+
+This project includes several utility classes to help build tablet-friendly layouts between 768px and 1024px.
+
+## Typography
+- `.h1-responsive` – `clamp(18px, 2.2vw, 22px)` with `line-height:1.3`
+- `.h2-responsive` – `clamp(16px, 2vw, 20px)` with `line-height:1.35`
+- `.h3-responsive` – `clamp(14px, 1.8vw, 18px)` with `line-height:1.4`
+
+Apply these classes to heading elements to keep titles readable on tablets.
+
+## Spacing
+Use the existing spacing helpers:
+- `.p-responsive`, `.px-responsive`, `.py-responsive`
+- `.gap-responsive`, `.space-y-responsive`
+
+These utilities provide `16–24px` padding and `12–24px` gaps across breakpoints.
+
+## Components
+- Buttons and inputs now enforce a minimum touch target of `44px`.
+- Tables are wrapped in `overflow-x-auto` with sticky headers for horizontal scrolling.
+- The sidebar collapses into a drawer on screens under `1024px`.
+
+Use Tailwind `md:` and `lg:` prefixes for tablet portrait and landscape adjustments respectively.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -46,7 +46,7 @@ export const Header = () => {
           <div className="w-5 h-5 sm:w-6 sm:h-6 lg:w-8 lg:h-8 bg-gradient-to-br from-marine-500 to-ocean-500 rounded-lg flex items-center justify-center flex-shrink-0">
             <span className="text-white font-bold text-xs lg:text-sm">CC</span>
           </div>
-          <h1 className="text-xs sm:text-lg lg:text-xl font-semibold text-gray-900 hidden xs:block truncate">Corail Caraibes</h1>
+          <h1 className="text-xs sm:text-lg lg:text-xl h1-responsive font-semibold text-gray-900 hidden xs:block truncate">Corail Caraibes</h1>
         </div>
       </div>
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,10 +21,11 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-3 py-1.5 sm:h-10 sm:px-4 sm:py-2",
-        sm: "h-8 rounded-md px-2.5 text-xs sm:h-9 sm:px-3 sm:text-sm",
-        lg: "h-10 rounded-md px-6 sm:h-11 sm:px-8",
-        icon: "h-9 w-9 sm:h-10 sm:w-10",
+        default:
+          "min-h-[44px] min-w-[44px] px-4 py-2",
+        sm: "min-h-[44px] rounded-md px-3 text-sm",
+        lg: "min-h-[48px] rounded-md px-6 sm:px-8",
+        icon: "min-h-[44px] min-w-[44px]", 
       },
     },
     defaultVariants: {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex min-h-[44px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -3,7 +3,7 @@ import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
-import { useIsMobile } from "@/hooks/use-mobile"
+import { useIsTablet } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -65,7 +65,7 @@ const SidebarProvider = React.forwardRef<
     },
     ref
   ) => {
-    const isMobile = useIsMobile()
+    const isMobile = useIsTablet()
     const [openMobile, setOpenMobile] = React.useState(false)
 
     // This is the internal state of the sidebar.

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -6,7 +6,7 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div className="relative w-full overflow-x-auto">
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}
@@ -20,7 +20,7 @@ const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+  <thead ref={ref} className={cn("sticky top-0 bg-background [&_tr]:border-b", className)} {...props} />
 ))
 TableHeader.displayName = "TableHeader"
 

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
+const TABLET_BREAKPOINT = 1024
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
@@ -16,4 +17,20 @@ export function useIsMobile() {
   }, [])
 
   return !!isMobile
+}
+
+export function useIsTablet() {
+  const [isTablet, setIsTablet] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${TABLET_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsTablet(window.innerWidth < TABLET_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsTablet(window.innerWidth < TABLET_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isTablet
 }

--- a/src/index.css
+++ b/src/index.css
@@ -157,7 +157,25 @@
   .status-inactive {
     @apply bg-destructive/10 text-destructive;
   }
-  
+
+  /* Fluid heading scale for tablet */
+  @media (min-width: 768px) and (max-width: 1023px) {
+    .h1-responsive {
+      font-size: clamp(18px, 2.2vw, 22px);
+      line-height: 1.3;
+    }
+
+    .h2-responsive {
+      font-size: clamp(16px, 2vw, 20px);
+      line-height: 1.35;
+    }
+
+    .h3-responsive {
+      font-size: clamp(14px, 1.8vw, 18px);
+      line-height: 1.4;
+    }
+  }
+
   /* Responsive text utilities */
   .text-responsive-sm {
     @apply text-xs sm:text-sm;


### PR DESCRIPTION
## Summary
- add fluid typography utilities for tablet breakpoints
- ensure buttons, inputs and tables meet 44px touch targets and scroll requirements
- collapse sidebar into drawer for screens under 1024px
- limit tablet typography utilities to 768–1023px and restore full-width desktop layout

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bded197a6c832d8741843bb8e01a9e