### PR TITLE
feat: improve supplier dialog responsiveness

### DIFF
--- a/src/components/suppliers/SupplierDetailsDialog.tsx
+++ b/src/components/suppliers/SupplierDetailsDialog.tsx
@@ -35,7 +35,7 @@ export function SupplierDetailsDialog({ isOpen, onClose, supplier }: SupplierDet
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-[95vw] sm:max-w-4xl max-h-[95vh] overflow-y-auto p-4 sm:p-6">
+      <DialogContent className="w-full max-w-[95vw] sm:max-w-lg md:max-w-2xl lg:max-w-4xl max-h-[95vh] overflow-y-auto overflow-x-hidden p-4 sm:p-6">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Building2 className="h-5 w-5" />
@@ -57,7 +57,7 @@ export function SupplierDetailsDialog({ isOpen, onClose, supplier }: SupplierDet
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
                 {/* Contact */}
                 <div className="space-y-3">
                   <h4 className="font-medium flex items-center gap-2">

--- a/src/components/suppliers/SupplierQuotesHistory.tsx
+++ b/src/components/suppliers/SupplierQuotesHistory.tsx
@@ -420,86 +420,85 @@ export function SupplierQuotesHistory({ supplier }: SupplierQuotesHistoryProps) 
 
       {/* Quotes Table */}
       {quotes.length > 0 ? (
-        <div className="overflow-x-auto">
-          <Table className="min-w-[800px]">
-          <TableHeader>
-            <TableRow>
-              <TableHead className="min-w-[200px]">Article</TableHead>
-              <TableHead className="min-w-[120px]">Référence devis</TableHead>
-              <TableHead className="min-w-[100px]">Prix unitaire</TableHead>
-              <TableHead className="min-w-[80px]">Qté min</TableHead>
-              <TableHead className="min-w-[90px]">Date</TableHead>
-              <TableHead className="min-w-[90px]">Validité</TableHead>
-              <TableHead className="min-w-[70px]">Délai</TableHead>
-              <TableHead className="min-w-[100px]">Statut</TableHead>
-              <TableHead className="text-right min-w-[120px]">Actions</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {quotes.map((quote) => (
-              <TableRow key={quote.id}>
-                <TableCell>
-                  <div>
-                    <div className="font-medium">{quote.stock_item.name}</div>
-                    {quote.stock_item.reference && (
-                      <div className="text-sm text-muted-foreground">
-                        Ref: {quote.stock_item.reference}
+        <div className="overflow-x-hidden">
+          <Table className="w-full text-sm">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Article</TableHead>
+                <TableHead className="hidden sm:table-cell">Référence devis</TableHead>
+                <TableHead>Prix unitaire</TableHead>
+                <TableHead className="hidden md:table-cell">Qté min</TableHead>
+                <TableHead className="hidden lg:table-cell">Date</TableHead>
+                <TableHead className="hidden lg:table-cell">Validité</TableHead>
+                <TableHead className="hidden xl:table-cell">Délai</TableHead>
+                <TableHead>Statut</TableHead>
+                <TableHead className="text-right hidden sm:table-cell">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {quotes.map((quote) => (
+                <TableRow key={quote.id}>
+                  <TableCell>
+                    <div>
+                      <div className="font-medium">{quote.stock_item.name}</div>
+                      {quote.stock_item.reference && (
+                        <div className="text-sm text-muted-foreground">
+                          Ref: {quote.stock_item.reference}
+                        </div>
+                      )}
+                      {quote.stock_item.category && (
+                        <Badge variant="outline" className="text-xs">
+                          {quote.stock_item.category}
+                        </Badge>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="hidden sm:table-cell">
+                    {quote.quote_number || '-'}
+                  </TableCell>
+                  <TableCell className="font-medium">
+                    {quote.unit_price.toFixed(2)} {quote.currency}
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell">{quote.minimum_quantity}</TableCell>
+                  <TableCell className="hidden lg:table-cell">
+                    {new Date(quote.quote_date).toLocaleDateString('fr-FR')}
+                  </TableCell>
+                  <TableCell className="hidden lg:table-cell">
+                    {quote.validity_date
+                      ? new Date(quote.validity_date).toLocaleDateString('fr-FR')
+                      : '-'}
+                  </TableCell>
+                  <TableCell className="hidden xl:table-cell">{quote.delivery_days} j.</TableCell>
+                  <TableCell>{getStatusBadge(quote.status)}</TableCell>
+                  <TableCell className="text-right hidden sm:table-cell">
+                    {quote.status === 'received' && (
+                      <div className="flex justify-end space-x-1">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => updateQuoteStatusMutation.mutate({
+                            quoteId: quote.id,
+                            status: 'selected'
+                          })}
+                        >
+                          <CheckCircle className="h-3 w-3" />
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => updateQuoteStatusMutation.mutate({
+                            quoteId: quote.id,
+                            status: 'rejected'
+                          })}
+                        >
+                          <XCircle className="h-3 w-3" />
+                        </Button>
                       </div>
                     )}
-                    {quote.stock_item.category && (
-                      <Badge variant="outline" className="text-xs">
-                        {quote.stock_item.category}
-                      </Badge>
-                    )}
-                  </div>
-                </TableCell>
-                <TableCell>
-                  {quote.quote_number || '-'}
-                </TableCell>
-                <TableCell className="font-medium">
-                  {quote.unit_price.toFixed(2)} {quote.currency}
-                </TableCell>
-                <TableCell>{quote.minimum_quantity}</TableCell>
-                <TableCell>
-                  {new Date(quote.quote_date).toLocaleDateString('fr-FR')}
-                </TableCell>
-                <TableCell>
-                  {quote.validity_date 
-                    ? new Date(quote.validity_date).toLocaleDateString('fr-FR')
-                    : '-'
-                  }
-                </TableCell>
-                <TableCell>{quote.delivery_days} j.</TableCell>
-                <TableCell>{getStatusBadge(quote.status)}</TableCell>
-                <TableCell className="text-right">
-                  {quote.status === 'received' && (
-                    <div className="flex justify-end space-x-1">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => updateQuoteStatusMutation.mutate({ 
-                          quoteId: quote.id, 
-                          status: 'selected' 
-                        })}
-                      >
-                        <CheckCircle className="h-3 w-3" />
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => updateQuoteStatusMutation.mutate({ 
-                          quoteId: quote.id, 
-                          status: 'rejected' 
-                        })}
-                      >
-                        <XCircle className="h-3 w-3" />
-                      </Button>
-                    </div>
-                  )}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
           </Table>
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- adjust supplier details dialog to handle mobile, tablet and desktop layouts
- refactor supplier quotes history table to avoid horizontal scrolling and adapt columns per breakpoint

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1d2692480832da18cc117f04982c1