### PR TITLE
Show requester name on supply requests

### DIFF
--- a/src/pages/SupplyRequests.tsx
+++ b/src/pages/SupplyRequests.tsx
@@ -59,7 +59,11 @@ export default function SupplyRequests() {
     queryFn: async () => {
       let query = supabase
         .from('supply_requests')
-        .select('*')
+        .select(`
+          *,
+          boat:boats(name),
+          requester:profiles!supply_requests_requested_by_fkey(name)
+        `)
         .order('created_at', { ascending: false });
 
       if (user?.role !== 'direction') {
@@ -212,7 +216,7 @@ export default function SupplyRequests() {
                 )}
 
                 <div className="text-xs text-muted-foreground">
-                  Demandé par: Utilisateur
+                  Demandé par: {request.requester?.name || 'N/A'}
                 </div>
 
                 <div className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- load requester and boat details when fetching supply requests
- display requesting user's name in supply request cards

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1d2c8e5c8832da1587bafcdc1f042