### PR TITLE
Fix manual linking of scans to supply requests

### DIFF
--- a/src/components/stock/OrderLinkDialog.tsx
+++ b/src/components/stock/OrderLinkDialog.tsx
@@ -61,12 +61,12 @@ export function OrderLinkDialog({
     enabled: isOpen && !!stockItemId,
   });
 
-  const handleLinkToOrder = async (requestId: string) => {
+  const handleLinkToRequest = async (requestId: string) => {
     setIsLinking(true);
     try {
-      const { data, error } = await supabase.rpc('link_stock_scan_to_order', {
+      const { data, error } = await supabase.rpc('link_stock_scan_to_supply_request', {
         stock_item_id_param: stockItemId,
-        order_id_param: requestId,
+        request_id_param: requestId,
         quantity_received_param: quantityReceived
       });
 
@@ -138,7 +138,7 @@ export function OrderLinkDialog({
                       </div>
                       <Button
                         size="sm"
-                        onClick={() => handleLinkToOrder(request.id)}
+                        onClick={() => handleLinkToRequest(request.id)}
                         disabled={isLinking}
                         className="flex items-center gap-1"
                       >

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4042,6 +4042,14 @@ export type Database = {
         }
         Returns: Json
       }
+      link_stock_scan_to_supply_request: {
+        Args: {
+          stock_item_id_param: string
+          request_id_param: string
+          quantity_received_param: number
+        }
+        Returns: Json
+      }
       mark_shipped: {
         Args: { p_shipment_id: string }
         Returns: boolean


### PR DESCRIPTION
## Summary
- Use `link_stock_scan_to_supply_request` RPC so the "Lier" button completes supply requests
- Add RPC type definition for `link_stock_scan_to_supply_request`

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js'; `npm install` also fails with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1defbd358832db75015458c2cd477